### PR TITLE
Fix issue #71: [RULE] Enforce Usage of `HttpsError` Instead of `throw…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "requireindex": "1.2.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { noUselessFragment } from './rules/no-useless-fragment';
 import { preferFragmentShorthand } from './rules/prefer-fragment-shorthand';
 import { preferTypeOverInterface } from './rules/prefer-type-over-interface';
 import { requireMemo } from './rules/require-memo';
+import { default as requireHttpsError } from './rules/require-https-error';
 
 module.exports = {
   meta: {
@@ -45,6 +46,7 @@ module.exports = {
         '@blumintinc/blumint/prefer-fragment-shorthand': 'warn',
         '@blumintinc/blumint/prefer-type-over-interface': 'warn',
         '@blumintinc/blumint/require-memo': 'error',
+        '@blumintinc/blumint/require-https-error': 'error',
       },
     },
   },
@@ -66,5 +68,6 @@ module.exports = {
     'prefer-fragment-shorthand': preferFragmentShorthand,
     'prefer-type-over-interface': preferTypeOverInterface,
     'require-memo': requireMemo,
+    'require-https-error': requireHttpsError,
   },
 };

--- a/src/rules/require-https-error.ts
+++ b/src/rules/require-https-error.ts
@@ -1,0 +1,42 @@
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/createRule';
+
+export = createRule({
+  name: 'require-https-error',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce using HttpsError instead of throw new Error in functions/src',
+      recommended: 'error',
+    },
+    schema: [],
+    messages: {
+      useHttpsError: 'Use HttpsError instead of throw new Error in functions/src directory',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const filename = context.getFilename();
+
+    // Only apply rule to files in functions/src directory
+    if (!filename.includes('functions/src')) {
+      return {};
+    }
+
+    return {
+      ThrowStatement(node: TSESTree.ThrowStatement) {
+        if (
+          node.argument &&
+          node.argument.type === AST_NODE_TYPES.NewExpression &&
+          node.argument.callee.type === AST_NODE_TYPES.Identifier &&
+          node.argument.callee.name === 'Error'
+        ) {
+          context.report({
+            node,
+            messageId: 'useHttpsError',
+          });
+        }
+      },
+    };
+  },
+});

--- a/src/rules/require-https-error.ts
+++ b/src/rules/require-https-error.ts
@@ -6,12 +6,14 @@ export = createRule({
   meta: {
     type: 'problem',
     docs: {
-      description: 'Enforce using HttpsError instead of throw new Error in functions/src',
+      description:
+        'Enforce using HttpsError instead of throw new Error in functions/src',
       recommended: 'error',
     },
     schema: [],
     messages: {
-      useHttpsError: 'Use HttpsError instead of throw new Error in functions/src directory',
+      useHttpsError:
+        'Use HttpsError instead of throw new Error in functions/src directory',
     },
   },
   defaultOptions: [],
@@ -25,11 +27,13 @@ export = createRule({
 
     return {
       ThrowStatement(node: TSESTree.ThrowStatement) {
+        const argument = node.argument as unknown as TSESTree.NewExpression;
         if (
-          node.argument &&
-          node.argument.type === AST_NODE_TYPES.NewExpression &&
-          node.argument.callee.type === AST_NODE_TYPES.Identifier &&
-          node.argument.callee.name === 'Error'
+          argument &&
+          argument.type === AST_NODE_TYPES.NewExpression &&
+          argument.callee &&
+          argument.callee.type === AST_NODE_TYPES.Identifier &&
+          argument.callee.name === 'Error'
         ) {
           context.report({
             node,

--- a/src/rules/require-https-error.ts
+++ b/src/rules/require-https-error.ts
@@ -7,13 +7,15 @@ export = createRule({
     type: 'problem',
     docs: {
       description:
-        'Enforce using HttpsError instead of throw new Error in functions/src',
+        'Enforce using proprietary HttpsError instead of throw new Error or firebase-admin HttpsError in functions/src',
       recommended: 'error',
     },
     schema: [],
     messages: {
       useHttpsError:
         'Use HttpsError instead of throw new Error in functions/src directory',
+      useProprietaryHttpsError:
+        'Use our proprietary HttpsError instead of firebase-admin HttpsError',
     },
   },
   defaultOptions: [],
@@ -25,20 +27,61 @@ export = createRule({
       return {};
     }
 
+    let hasFirebaseAdminImport = false;
+    let httpsIdentifier: string | null = null;
+
     return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        if (
+          node.source.value === 'firebase-admin' ||
+          node.source.value === 'firebase-admin/lib/https-error'
+        ) {
+          hasFirebaseAdminImport = true;
+          // Track the local name of the https import
+          const httpsSpecifier = node.specifiers.find(
+            (spec) =>
+              spec.type === AST_NODE_TYPES.ImportSpecifier &&
+              spec.imported.name === 'https',
+          );
+          if (httpsSpecifier && 'local' in httpsSpecifier) {
+            httpsIdentifier = httpsSpecifier.local.name;
+          }
+          context.report({
+            node,
+            messageId: 'useProprietaryHttpsError',
+          });
+        }
+      },
       ThrowStatement(node: TSESTree.ThrowStatement) {
         const argument = node.argument as unknown as TSESTree.NewExpression;
         if (
           argument &&
           argument.type === AST_NODE_TYPES.NewExpression &&
-          argument.callee &&
-          argument.callee.type === AST_NODE_TYPES.Identifier &&
-          argument.callee.name === 'Error'
+          argument.callee
         ) {
-          context.report({
-            node,
-            messageId: 'useHttpsError',
-          });
+          if (
+            argument.callee.type === AST_NODE_TYPES.Identifier &&
+            argument.callee.name === 'Error'
+          ) {
+            context.report({
+              node,
+              messageId: 'useHttpsError',
+            });
+          } else if (
+            hasFirebaseAdminImport &&
+            ((argument.callee.type === AST_NODE_TYPES.Identifier &&
+              argument.callee.name === 'HttpsError') ||
+              (argument.callee.type === AST_NODE_TYPES.MemberExpression &&
+                argument.callee.object.type === AST_NODE_TYPES.Identifier &&
+                argument.callee.object.name === httpsIdentifier &&
+                argument.callee.property.type === AST_NODE_TYPES.Identifier &&
+                argument.callee.property.name === 'HttpsError'))
+          ) {
+            context.report({
+              node,
+              messageId: 'useProprietaryHttpsError',
+            });
+          }
         }
       },
     };

--- a/src/tests/require-https-error.test.ts
+++ b/src/tests/require-https-error.test.ts
@@ -1,7 +1,7 @@
-import { ruleTester } from '../utils/ruleTester';
-import rule = require('../rules/require-https-error');
+import { ruleTesterTs } from '../utils/ruleTester';
+import requireHttpsError from '../rules/require-https-error';
 
-ruleTester.run('require-https-error', rule, {
+ruleTesterTs.run('require-https-error', requireHttpsError, {
   valid: [
     // Should allow throw new Error outside functions/src
     {

--- a/src/tests/require-https-error.test.ts
+++ b/src/tests/require-https-error.test.ts
@@ -1,0 +1,36 @@
+import { ruleTester } from '../utils/ruleTester';
+import rule = require('../rules/require-https-error');
+
+ruleTester.run('require-https-error', rule, {
+  valid: [
+    // Should allow throw new Error outside functions/src
+    {
+      code: 'throw new Error("test error");',
+      filename: 'src/components/test.ts',
+    },
+    // Should allow throw new HttpsError in functions/src
+    {
+      code: 'throw new HttpsError("INVALID_ARGUMENT", "test error");',
+      filename: 'functions/src/test.ts',
+    },
+    // Should allow throw new CustomError in functions/src
+    {
+      code: 'throw new CustomError("test error");',
+      filename: 'functions/src/test.ts',
+    },
+  ],
+  invalid: [
+    // Should not allow throw new Error in functions/src
+    {
+      code: 'throw new Error("test error");',
+      filename: 'functions/src/test.ts',
+      errors: [{ messageId: 'useHttpsError' }],
+    },
+    // Should not allow throw new Error with multiple arguments in functions/src
+    {
+      code: 'throw new Error("test error", "additional info");',
+      filename: 'functions/src/test.ts',
+      errors: [{ messageId: 'useHttpsError' }],
+    },
+  ],
+});

--- a/src/tests/require-https-error.test.ts
+++ b/src/tests/require-https-error.test.ts
@@ -3,14 +3,9 @@ import requireHttpsError from '../rules/require-https-error';
 
 ruleTesterTs.run('require-https-error', requireHttpsError, {
   valid: [
-    // Should allow throw new Error outside functions/src
+    // Should allow throw new HttpsError
     {
-      code: 'throw new Error("test error");',
-      filename: 'src/components/test.ts',
-    },
-    // Should allow throw new HttpsError in functions/src
-    {
-      code: 'throw new HttpsError("INVALID_ARGUMENT", "test error");',
+      code: 'import { HttpsError } from "@our-company/errors"; throw new HttpsError("INVALID_ARGUMENT", "test error");',
       filename: 'functions/src/test.ts',
     },
     // Should allow throw new CustomError in functions/src
@@ -31,6 +26,42 @@ ruleTesterTs.run('require-https-error', requireHttpsError, {
       code: 'throw new Error("test error", "additional info");',
       filename: 'functions/src/test.ts',
       errors: [{ messageId: 'useHttpsError' }],
+    },
+    // Should not allow firebase-admin HttpsError import
+    {
+      code: 'import { HttpsError } from "firebase-admin"; throw new HttpsError("failed-precondition", "test error");',
+      filename: 'functions/src/test.ts',
+      errors: [
+        { messageId: 'useProprietaryHttpsError' },
+        { messageId: 'useProprietaryHttpsError' },
+      ],
+    },
+    // Should not allow firebase-admin/lib/https-error import
+    {
+      code: 'import { HttpsError } from "firebase-admin/lib/https-error"; throw new HttpsError("failed-precondition", "test error");',
+      filename: 'functions/src/test.ts',
+      errors: [
+        { messageId: 'useProprietaryHttpsError' },
+        { messageId: 'useProprietaryHttpsError' },
+      ],
+    },
+    // Should not allow firebase-admin https.HttpsError usage
+    {
+      code: 'import { https } from "firebase-admin"; throw new https.HttpsError("failed-precondition", "test error");',
+      filename: 'functions/src/test.ts',
+      errors: [
+        { messageId: 'useProprietaryHttpsError' },
+        { messageId: 'useProprietaryHttpsError' },
+      ],
+    },
+    // Should not allow renamed firebase-admin https import
+    {
+      code: 'import { https as firebaseHttps } from "firebase-admin"; throw new firebaseHttps.HttpsError("failed-precondition", "test error");',
+      filename: 'functions/src/test.ts',
+      errors: [
+        { messageId: 'useProprietaryHttpsError' },
+        { messageId: 'useProprietaryHttpsError' },
+      ],
     },
   ],
 });


### PR DESCRIPTION
Fixes #71 
… new Error` in `functions/src`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new rule, `require-https-error`, to enforce the use of `HttpsError` in specific directories.

- **Bug Fixes**
	- Added error reporting for violations of the `require-https-error` rule.

- **Tests**
	- Implemented tests for the `require-https-error` rule to validate correct error handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->