### PR TITLE
Fix issue #67: [RULE] Ensure Dynamic Imports for Firebase Dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "requireindex": "1.2.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { noUselessFragment } from './rules/no-useless-fragment';
 import { preferFragmentShorthand } from './rules/prefer-fragment-shorthand';
 import { preferTypeOverInterface } from './rules/prefer-type-over-interface';
 import { requireMemo } from './rules/require-memo';
+import { default as requireDynamicFirebaseImports } from './rules/require-dynamic-firebase-imports';
 
 module.exports = {
   meta: {
@@ -45,6 +46,7 @@ module.exports = {
         '@blumintinc/blumint/prefer-fragment-shorthand': 'warn',
         '@blumintinc/blumint/prefer-type-over-interface': 'warn',
         '@blumintinc/blumint/require-memo': 'error',
+        '@blumintinc/blumint/require-dynamic-firebase-imports': 'error',
       },
     },
   },
@@ -66,5 +68,6 @@ module.exports = {
     'prefer-fragment-shorthand': preferFragmentShorthand,
     'prefer-type-over-interface': preferTypeOverInterface,
     'require-memo': requireMemo,
+    'require-dynamic-firebase-imports': requireDynamicFirebaseImports,
   },
 };

--- a/src/rules/require-dynamic-firebase-imports.ts
+++ b/src/rules/require-dynamic-firebase-imports.ts
@@ -1,0 +1,86 @@
+import { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/createRule';
+
+export const RULE_NAME = 'require-dynamic-firebase-imports';
+
+export default createRule({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce dynamic imports for Firebase dependencies',
+      recommended: 'error',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      requireDynamicImport: 'Firebase dependencies must be imported dynamically to reduce bundle size',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const isFirebaseImport = (source: string): boolean => {
+      return source.startsWith('firebase/') || source.includes('config/firebase-client');
+    };
+
+    const createDynamicImport = (node: TSESTree.ImportDeclaration): string => {
+      const importSource = node.source.value;
+      const importSpecifiers = node.specifiers;
+      
+      if (importSpecifiers.length === 0) {
+        // For side-effect imports like 'firebase/auth'
+        return `await import('${importSource}');`;
+      }
+
+      if (importSpecifiers.length === 1) {
+        const spec = importSpecifiers[0];
+        if (spec.type === 'ImportDefaultSpecifier') {
+          // For default imports
+          return `const ${spec.local.name} = (await import('${importSource}')).default;`;
+        }
+        if (spec.type === 'ImportSpecifier') {
+          // For single named import
+          const importedName = spec.imported.name;
+          const localName = spec.local.name;
+          if (importedName === localName) {
+            return `const { ${localName} } = await import('${importSource}');`;
+          }
+          return `const { ${importedName} as ${localName} } = await import('${importSource}');`;
+        }
+      }
+
+      // For multiple named imports
+      const importedModule = `await import('${importSource}')`;
+      const namedImports = importSpecifiers
+        .map((spec) => {
+          if (spec.type === 'ImportSpecifier') {
+            const importedName = spec.imported.name;
+            const localName = spec.local.name;
+            return importedName === localName ? localName : `${importedName} as ${localName}`;
+          }
+          return '';
+        })
+        .filter(Boolean)
+        .join(', ');
+
+      return `const { ${namedImports} } = ${importedModule};`;
+    };
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        const importSource = node.source.value;
+
+        if (typeof importSource === 'string' && isFirebaseImport(importSource)) {
+          context.report({
+            node,
+            messageId: 'requireDynamicImport',
+            fix(fixer) {
+              const dynamicImport = createDynamicImport(node);
+              return fixer.replaceText(node, dynamicImport);
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/src/tests/require-dynamic-firebase-imports.test.ts
+++ b/src/tests/require-dynamic-firebase-imports.test.ts
@@ -51,7 +51,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `import { getAuth as auth } from 'firebase/auth';`,
       errors: [{ messageId: 'requireDynamicImport' }],
-      output: `const { getAuth as auth } = await import('firebase/auth');`,
+      output: `const { getAuth: auth } = await import('firebase/auth');`,
     },
   ],
 });

--- a/src/tests/require-dynamic-firebase-imports.test.ts
+++ b/src/tests/require-dynamic-firebase-imports.test.ts
@@ -1,0 +1,57 @@
+import { ruleTesterTs } from '../utils/ruleTester';
+import rule, { RULE_NAME } from '../rules/require-dynamic-firebase-imports';
+
+const ruleTester = ruleTesterTs;
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    // Non-Firebase imports should be valid
+    {
+      code: `import React from 'react';`,
+    },
+    {
+      code: `import { useState } from 'react';`,
+    },
+    {
+      code: `import apiClient from '@/utils/apiClient';`,
+    },
+  ],
+  invalid: [
+    // Default import from firebase
+    {
+      code: `import firebase from 'firebase/app';`,
+      errors: [{ messageId: 'requireDynamicImport' }],
+      output: `const firebase = (await import('firebase/app')).default;`,
+    },
+    // Side-effect import
+    {
+      code: `import 'firebase/auth';`,
+      errors: [{ messageId: 'requireDynamicImport' }],
+      output: `await import('firebase/auth');`,
+    },
+    // Named imports
+    {
+      code: `import { getAuth } from 'firebase/auth';`,
+      errors: [{ messageId: 'requireDynamicImport' }],
+      output: `const { getAuth } = await import('firebase/auth');`,
+    },
+    // Multiple named imports
+    {
+      code: `import { getAuth, signInWithEmailAndPassword } from 'firebase/auth';`,
+      errors: [{ messageId: 'requireDynamicImport' }],
+      output: `const { getAuth, signInWithEmailAndPassword } = await import('firebase/auth');`,
+    },
+    // Firebase config import
+    {
+      code: `import firebaseConfig from '../../config/firebase-client';`,
+      errors: [{ messageId: 'requireDynamicImport' }],
+      output: `const firebaseConfig = (await import('../../config/firebase-client')).default;`,
+    },
+    // Named imports with aliases
+    {
+      code: `import { getAuth as auth } from 'firebase/auth';`,
+      errors: [{ messageId: 'requireDynamicImport' }],
+      output: `const { getAuth as auth } = await import('firebase/auth');`,
+    },
+  ],
+});


### PR DESCRIPTION
Fixes #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new ESLint rule to enforce dynamic imports for Firebase dependencies.
	- Added a test suite to validate the new ESLint rule against various import scenarios.

- **Bug Fixes**
	- Enhanced error reporting for static Firebase imports, providing suggestions for dynamic import syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->