### PR TITLE
Fix issue #69: [RULE] Use src/components/Link instead of importing ne…

### DIFF
--- a/src/rules/use-custom-link.ts
+++ b/src/rules/use-custom-link.ts
@@ -1,0 +1,51 @@
+import { createRule } from '../utils/createRule';
+
+export const useCustomLink = createRule({
+  name: 'use-custom-link',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce using src/components/Link instead of next/link',
+      recommended: 'error',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      useCustomLink: 'Import Link from src/components/Link instead of next/link',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'next/link') {
+          const importSpecifiers = node.specifiers;
+          
+          // Handle different import types (default, named, namespace)
+          const hasDefaultImport = importSpecifiers.some(
+            (specifier) => specifier.type === 'ImportDefaultSpecifier'
+          );
+          
+          if (hasDefaultImport) {
+            context.report({
+              node,
+              messageId: 'useCustomLink',
+              fix(fixer) {
+                // Get the local name of the imported Link component
+                const defaultSpecifier = importSpecifiers.find(
+                  (specifier) => specifier.type === 'ImportDefaultSpecifier'
+                );
+                const localName = defaultSpecifier?.local?.name || 'Link';
+
+                // Create the new import statement
+                const newImport = `import ${localName} from 'src/components/Link';`;
+                
+                return fixer.replaceText(node, newImport);
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/tests/use-custom-link.test.ts
+++ b/src/tests/use-custom-link.test.ts
@@ -1,0 +1,39 @@
+import { RuleTester } from '../utils/ruleTester';
+import { useCustomLink } from '../rules/use-custom-link';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('use-custom-link', useCustomLink, {
+  valid: [
+    {
+      code: `import Link from 'src/components/Link';`,
+    },
+    {
+      code: `import { CustomComponent } from 'src/components/Link';`,
+    },
+    {
+      code: `import Link, { CustomComponent } from 'src/components/Link';`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import Link from 'next/link';`,
+      errors: [{ messageId: 'useCustomLink' }],
+      output: `import Link from 'src/components/Link';`,
+    },
+    {
+      code: `import { default as NextLink } from 'next/link';`,
+      errors: [{ messageId: 'useCustomLink' }],
+      output: `import NextLink from 'src/components/Link';`,
+    },
+  ],
+});

--- a/src/tests/use-custom-link.test.ts
+++ b/src/tests/use-custom-link.test.ts
@@ -1,18 +1,7 @@
-import { RuleTester } from '../utils/ruleTester';
+import { ruleTesterJsx } from '../utils/ruleTester';
 import { useCustomLink } from '../rules/use-custom-link';
 
-const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 2018,
-    sourceType: 'module',
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
-});
-
-ruleTester.run('use-custom-link', useCustomLink, {
+ruleTesterJsx.run('use-custom-link', useCustomLink, {
   valid: [
     {
       code: `import Link from 'src/components/Link';`,


### PR DESCRIPTION
…xt/link directly

Fixes #69 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new rule, `useCustomLink`, to enforce the use of a specific Link component.
  
- **Bug Fixes**
	- The rule provides automatic fixes for incorrect import statements.

- **Tests**
	- Added a test suite to validate the functionality of the `useCustomLink` rule, including both valid and invalid import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->