### PR TITLE
Fix issue #80: [RULE] useMemo inline object literals passed to props …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "requireindex": "1.2.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { noUselessFragment } from './rules/no-useless-fragment';
 import { preferFragmentShorthand } from './rules/prefer-fragment-shorthand';
 import { preferTypeOverInterface } from './rules/prefer-type-over-interface';
 import { requireMemo } from './rules/require-memo';
+import { requireUseMemoObjectLiterals } from './rules/require-usememo-object-literals';
 
 module.exports = {
   meta: {
@@ -45,6 +46,7 @@ module.exports = {
         '@blumintinc/blumint/prefer-fragment-shorthand': 'warn',
         '@blumintinc/blumint/prefer-type-over-interface': 'warn',
         '@blumintinc/blumint/require-memo': 'error',
+        '@blumintinc/blumint/require-usememo-object-literals': 'error',
       },
     },
   },
@@ -66,5 +68,6 @@ module.exports = {
     'prefer-fragment-shorthand': preferFragmentShorthand,
     'prefer-type-over-interface': preferTypeOverInterface,
     'require-memo': requireMemo,
+    'require-usememo-object-literals': requireUseMemoObjectLiterals,
   },
 };

--- a/src/rules/require-usememo-object-literals.ts
+++ b/src/rules/require-usememo-object-literals.ts
@@ -1,0 +1,53 @@
+import { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/createRule';
+
+export const requireUseMemoObjectLiterals = createRule({
+  name: 'require-usememo-object-literals',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Enforce using useMemo for inline object literals passed as props to JSX components',
+      recommended: 'error',
+    },
+    messages: {
+      requireUseMemo: 'Inline object/array literals in JSX props should be wrapped in useMemo to prevent unnecessary re-renders',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        // Skip if the value is not an expression
+        if (!node.value || node.value.type !== 'JSXExpressionContainer') {
+          return;
+        }
+
+        const { expression } = node.value;
+
+        // Check if the expression is an object or array literal
+        if (
+          (expression.type === 'ObjectExpression' || expression.type === 'ArrayExpression') &&
+          // Ensure we're in a function component context
+          context.getAncestors().some(ancestor => 
+            ancestor.type === 'FunctionDeclaration' || 
+            ancestor.type === 'ArrowFunctionExpression' ||
+            ancestor.type === 'FunctionExpression'
+          )
+        ) {
+          // Check if the parent component name starts with an uppercase letter
+          // to ensure it's a React component
+          const jsxElement = node.parent as TSESTree.JSXOpeningElement;
+          const elementName = jsxElement.name.type === 'JSXIdentifier' ? jsxElement.name.name : '';
+          
+          if (elementName && /^[A-Z]/.test(elementName)) {
+            context.report({
+              node: expression,
+              messageId: 'requireUseMemo',
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/tests/require-usememo-object-literals.test.ts
+++ b/src/tests/require-usememo-object-literals.test.ts
@@ -1,0 +1,93 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { requireUseMemoObjectLiterals } from '../rules/require-usememo-object-literals';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('require-usememo-object-literals', requireUseMemoObjectLiterals, {
+  valid: [
+    // Valid case: using useMemo for object literal
+    {
+      code: `
+        function Component() {
+          const buttons = useMemo(() => [
+            {
+              isAsync: false,
+              color: 'primary',
+              onClick: handleClick,
+              children: 'Click me',
+            },
+          ], [handleClick]);
+          return <DialogActions buttons={buttons} />;
+        }
+      `,
+    },
+    // Valid case: non-literal prop
+    {
+      code: `
+        function Component() {
+          const config = { foo: 'bar' };
+          return <MyComponent prop={config} />;
+        }
+      `,
+    },
+    // Valid case: primitive prop
+    {
+      code: `
+        function Component() {
+          return <MyComponent prop={42} />;
+        }
+      `,
+    },
+    // Valid case: lowercase component (HTML element)
+    {
+      code: `
+        function Component() {
+          return <div style={{ color: 'red' }} />;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    // Invalid case: inline object literal
+    {
+      code: `
+        function Component() {
+          return <DialogActions buttons={[{
+            isAsync: false,
+            color: 'primary',
+            onClick: handleClick,
+            children: 'Click me',
+          }]} />;
+        }
+      `,
+      errors: [{ messageId: 'requireUseMemo' }],
+    },
+    // Invalid case: inline object literal in prop
+    {
+      code: `
+        function Component() {
+          return <MyComponent config={{ foo: 'bar', baz: 42 }} />;
+        }
+      `,
+      errors: [{ messageId: 'requireUseMemo' }],
+    },
+    // Invalid case: inline array literal
+    {
+      code: `
+        function Component() {
+          return <MyList items={['a', 'b', 'c']} />;
+        }
+      `,
+      errors: [{ messageId: 'requireUseMemo' }],
+    },
+  ],
+});


### PR DESCRIPTION
…of JSX components to prevent unnecessary re-renders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new ESLint rule to enforce the use of the `useMemo` hook for inline object and array literals in React components.
- **Bug Fixes**
	- Added error reporting for violations of the new rule in the recommended configuration.
- **Tests**
	- Implemented a test suite for the new rule, including both valid and invalid usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->