### PR TITLE
Fix issue #119: [BUG] [ESLINT] enforce-callable-types rule does not i…

### DIFF
--- a/src/rules/enforce-callable-types.ts
+++ b/src/rules/enforce-callable-types.ts
@@ -32,8 +32,12 @@ export const enforceCallableTypes = createRule<Options, MessageIds>({
   create(context) {
     const filename = context.getFilename();
 
-    // Only apply to .f.ts files in the callable directory
-    if (!filename.endsWith('.f.ts') || !filename.includes('/callable/')) {
+    // Only apply to .f.ts files in the callable directory, but ignore scripts directory
+    if (
+      !filename.endsWith('.f.ts') ||
+      !filename.includes('/callable/') ||
+      filename.includes('/callable/scripts/')
+    ) {
       return {};
     }
 

--- a/src/tests/enforce-callable-types.test.ts
+++ b/src/tests/enforce-callable-types.test.ts
@@ -55,6 +55,19 @@ ruleTester.run('enforce-callable-types', enforceCallableTypes, {
       `,
       filename: 'src/utils/helper.ts',
     },
+    {
+      // Files in callable/scripts directory should be ignored
+      code: `
+        import { onCall } from '../../v2/https/onCall';
+
+        export function scriptHandler(req, res) {
+          return { success: true };
+        }
+
+        export default onCall(scriptHandler);
+      `,
+      filename: 'src/callable/scripts/example.f.ts',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
…gnore specified directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the application scope of the `enforceCallableTypes` rule to exclude files in the `/callable/scripts/` directory.

- **Tests**
	- Added a new valid test case for the `enforceCallableTypes` rule, ensuring files in the `callable/scripts` directory are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->