### PR TITLE
Disallow inline component props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ import { noStaleStateAcrossAwait } from './rules/no-stale-state-across-await';
 import { noSeparateLoadingState } from './rules/no-separate-loading-state';
 import { optimizeObjectBooleanConditions } from './rules/optimize-object-boolean-conditions';
 import { preferParamsOverParentId } from './rules/prefer-params-over-parent-id';
+import { noInlineComponentProp } from './rules/no-inline-component-prop';
 
 module.exports = {
   meta: {
@@ -261,6 +262,7 @@ module.exports = {
         '@blumintinc/blumint/no-separate-loading-state': 'error',
         '@blumintinc/blumint/optimize-object-boolean-conditions': 'error',
         '@blumintinc/blumint/prefer-params-over-parent-id': 'error',
+        '@blumintinc/blumint/no-inline-component-prop': 'error',
       },
     },
   },
@@ -392,5 +394,6 @@ module.exports = {
     'no-separate-loading-state': noSeparateLoadingState,
     'optimize-object-boolean-conditions': optimizeObjectBooleanConditions,
     'prefer-params-over-parent-id': preferParamsOverParentId,
+    'no-inline-component-prop': noInlineComponentProp,
   },
 };

--- a/src/rules/no-inline-component-prop.ts
+++ b/src/rules/no-inline-component-prop.ts
@@ -1,0 +1,283 @@
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/createRule';
+import { minimatch as mm } from 'minimatch';
+
+// Options for the rule
+interface RuleOptions {
+	props?: string[];
+	allowRenderProps?: boolean;
+	allowModuleScopeFactories?: boolean;
+}
+
+type MessageIds = 'noInlineComponentProp';
+
+const DEFAULT_OPTIONS: Required<RuleOptions> = {
+	props: ['CatalogWrapper', '*Wrapper', '*Component'],
+	allowRenderProps: true,
+	allowModuleScopeFactories: true,
+};
+
+const DEFAULT_RENDER_PROP_NAMES = new Set([
+	'children',
+	'render',
+	'rowRenderer',
+	'renderRow',
+	'renderItem',
+	'itemRenderer',
+	'cellRenderer',
+]);
+
+function isModuleScope(node: TSESTree.Node): boolean {
+	let current: TSESTree.Node | undefined = node;
+	while (current) {
+		if (
+			current.type === AST_NODE_TYPES.FunctionDeclaration ||
+			current.type === AST_NODE_TYPES.FunctionExpression ||
+			current.type === AST_NODE_TYPES.ArrowFunctionExpression
+		) {
+			return false;
+		}
+		if (current.type === AST_NODE_TYPES.Program) return true;
+		current = current.parent;
+	}
+	return true;
+}
+
+function isInlineFunctionExpression(
+	node: TSESTree.Node | null | undefined,
+): node is
+	| TSESTree.ArrowFunctionExpression
+	| TSESTree.FunctionExpression {
+	if (!node) return false;
+	return (
+		node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+		node.type === AST_NODE_TYPES.FunctionExpression
+	);
+}
+
+function isUseCallbackOrMemoCall(node: TSESTree.Node): node is TSESTree.CallExpression {
+	if (node.type !== AST_NODE_TYPES.CallExpression) return false;
+	const callee = node.callee;
+	if (callee.type === AST_NODE_TYPES.Identifier) {
+		return callee.name === 'useCallback' || callee.name === 'useMemo';
+	}
+	if (
+		callee.type === AST_NODE_TYPES.MemberExpression &&
+		callee.property.type === AST_NODE_TYPES.Identifier &&
+		(callee.property.name === 'useCallback' || callee.property.name === 'useMemo')
+	) {
+		return true;
+	}
+	return false;
+}
+
+function matchesAnyPattern(name: string, patterns: string[]): boolean {
+	for (const pattern of patterns) {
+		if (mm(name, pattern, { nocase: false })) return true;
+	}
+	return false;
+}
+
+// Basic JSX detection
+function containsJsxInFunction(
+	node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+): boolean {
+	const body = node.body;
+	if (
+		body.type === AST_NODE_TYPES.JSXElement ||
+		body.type === AST_NODE_TYPES.JSXFragment
+	) {
+		return true;
+	}
+	if (body.type === AST_NODE_TYPES.BlockStatement) {
+		for (const stmt of body.body) {
+			if (
+				stmt.type === AST_NODE_TYPES.ReturnStatement &&
+				stmt.argument &&
+				(stmt.argument.type === AST_NODE_TYPES.JSXElement ||
+					stmt.argument.type === AST_NODE_TYPES.JSXFragment)
+			) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+function findVariableInScopeChain(context: any, name: string) {
+	let scope: any = context.getScope();
+	while (scope) {
+		const variable = scope.variables?.find((v: any) => v.name === name);
+		if (variable) return variable;
+		scope = scope.upper;
+	}
+	return undefined;
+}
+
+export const noInlineComponentProp = createRule<[RuleOptions?], MessageIds>({
+	name: 'no-inline-component-prop',
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Prohibit passing inline function components created in render to component-type props (e.g., CatalogWrapper). Use a stable, top-level memoized component instead.',
+			recommended: 'error',
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					props: {
+						type: 'array',
+						items: { type: 'string' },
+						default: DEFAULT_OPTIONS.props,
+					},
+					allowRenderProps: { type: 'boolean', default: true },
+					allowModuleScopeFactories: { type: 'boolean', default: true },
+				},
+				additionalProperties: false,
+			},
+		],
+		messages: {
+			noInlineComponentProp:
+				'Do not pass an inline component created in render to component-type props (e.g., CatalogWrapper). Use a stable, top-level memoized component and lift dynamic data via props or context to avoid remounts and UI flashes.',
+		},
+	},
+	defaultOptions: [DEFAULT_OPTIONS],
+	create(context, [options]) {
+		const opts: Required<RuleOptions> = {
+			...DEFAULT_OPTIONS,
+			...(options || {}),
+		};
+
+		function shouldCheckProp(propName: string): boolean {
+			if (opts.allowRenderProps && DEFAULT_RENDER_PROP_NAMES.has(propName)) {
+				return false;
+			}
+			return matchesAnyPattern(propName, opts.props);
+		}
+
+		function isDisallowedInlineFunction(node: TSESTree.Node): boolean {
+			if (isInlineFunctionExpression(node)) {
+				return true;
+			}
+
+			if (node.type === AST_NODE_TYPES.CallExpression) {
+				const callExprAny: any = node;
+				if (isUseCallbackOrMemoCall(node)) {
+					return true; // Always disallow useCallback/useMemo-created wrappers in render
+				}
+				// Also disallow React.memo at render scope
+				if (
+					callExprAny.callee?.type === AST_NODE_TYPES.Identifier &&
+					callExprAny.callee?.name === 'memo'
+				) {
+					return true;
+				}
+				if (
+					callExprAny.callee?.type === AST_NODE_TYPES.MemberExpression &&
+					callExprAny.callee?.property?.type === AST_NODE_TYPES.Identifier &&
+					callExprAny.callee?.property?.name === 'memo'
+				) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		function isTopLevelFactory(node: TSESTree.Node): boolean {
+			if (!opts.allowModuleScopeFactories) return false;
+			return isModuleScope(node);
+		}
+
+		return {
+			JSXAttribute(attribute: TSESTree.JSXAttribute) {
+				if (attribute.name.type !== AST_NODE_TYPES.JSXIdentifier) return;
+				const propName = attribute.name.name;
+				if (!shouldCheckProp(propName)) return;
+
+				const value = attribute.value;
+				if (!value) return; // boolean true props like <X CatalogWrapper /> not our concern
+
+				if (value.type === AST_NODE_TYPES.JSXExpressionContainer) {
+					const expr = value.expression;
+
+					// Case 1: Direct inline function expression passed
+					if (isDisallowedInlineFunction(expr)) {
+						// If created at module scope and allowed, skip
+						if (isTopLevelFactory(expr)) return;
+						context.report({ node: attribute, messageId: 'noInlineComponentProp' });
+						return;
+					}
+
+					// Case 2: Identifier referencing a local inline function definition
+					if (expr.type === AST_NODE_TYPES.Identifier) {
+						const variable = findVariableInScopeChain(context, expr.name);
+						if (!variable || !variable.defs || variable.defs.length === 0) {
+							return;
+						}
+
+						// If imported or global, skip
+						const hasImportDef = variable.defs.some(
+							(def: any) => def.type === 'ImportBinding',
+						);
+						if (hasImportDef) return;
+
+						for (const def of variable.defs) {
+							// Variable declarator
+							if (
+								def.type === 'Variable' &&
+								def.node &&
+								(def.node as TSESTree.VariableDeclarator).init
+							) {
+								const init = (def.node as TSESTree.VariableDeclarator)
+									.init!;
+
+								// If at module scope and allowed, skip
+								if (isTopLevelFactory(def.node)) continue;
+
+								if (isDisallowedInlineFunction(init)) {
+									context.report({
+										node: attribute,
+										messageId: 'noInlineComponentProp',
+									});
+									return;
+								}
+
+								// Special case: useMemo(() => () => <JSX />)
+								if (
+									isUseCallbackOrMemoCall(init) &&
+									init.arguments.length > 0
+								) {
+									const first = init.arguments[0];
+									if (
+										first.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+										first.type === AST_NODE_TYPES.FunctionExpression
+									) {
+										if (containsJsxInFunction(first)) {
+											context.report({
+												node: attribute,
+												messageId: 'noInlineComponentProp',
+											});
+											return;
+										}
+									}
+								}
+							}
+
+							// Function declaration within render scope
+							if (
+								def.type === 'FunctionName' &&
+								def.node &&
+								!isModuleScope(def.node)
+							) {
+								context.report({ node: attribute, messageId: 'noInlineComponentProp' });
+								return;
+							}
+						}
+					}
+				}
+			},
+		};
+	},
+});

--- a/src/tests/no-inline-component-prop.test.ts
+++ b/src/tests/no-inline-component-prop.test.ts
@@ -1,0 +1,168 @@
+import { ruleTesterJsx } from '../utils/ruleTester';
+import { noInlineComponentProp } from '../rules/no-inline-component-prop';
+
+ruleTesterJsx.run('no-inline-component-prop', noInlineComponentProp, {
+	valid: [
+		// Stable component reference passed
+		{
+			code: `
+import { memo } from 'react';
+const Wrapper = memo(function Wrapper(p: any){ return <div {...p}/> });
+function Page(){
+  return <AlgoliaLayout CatalogWrapper={Wrapper} />
+}
+`,
+		},
+		// Render prop allowed
+		{
+			code: `
+function Row({ row }: any){ return <div>{row}</div> }
+function Table(){
+  return <Grid rows={[]} render={(row)=> <Row row={row} />} />
+}
+`,
+			options: [{ allowRenderProps: true }],
+		},
+		// children allowed
+		{
+			code: `
+function Comp(){
+  return <Layout children={(x:any)=> <span>{x}</span>} />
+}
+`,
+			options: [{ allowRenderProps: true }],
+		},
+		// Top-level factory allowed when configured
+		{
+			code: `
+import { memo } from 'react';
+const makeWrapper = () => memo(function W(p:any){ return <div {...p}/> });
+const Stable = makeWrapper();
+function Page(){
+  return <AlgoliaLayout CatalogWrapper={Stable} />
+}
+`,
+			options: [{ allowModuleScopeFactories: true }],
+		},
+		// Different prop name via config
+		{
+			code: `
+const Good = (p:any)=> <div {...p}/>;
+function Page(){
+  return <Layout ItemComponent={Good} />
+}
+`,
+			options: [{ props: ['ItemComponent'] }],
+		},
+		// Inline function to non-component prop is fine
+		{
+			code: `
+function Page(){
+  return <Layout onClick={() => {}} />
+}
+`,
+		},
+		// Identifier imported (assumed stable)
+		{
+			code: `
+import { TeamsCarouselWrapper } from './wrappers';
+function Teams(){
+  return <AlgoliaLayout CatalogWrapper={TeamsCarouselWrapper} />
+}
+`,
+		},
+	],
+	invalid: [
+		// Inline arrow function
+		{
+			code: `
+function Page(){
+  return <AlgoliaLayout CatalogWrapper={(p:any)=> <div {...p}/> } />
+}
+`,
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+		// Inline function expression
+		{
+			code: `
+function Page(){
+  return <AlgoliaLayout CatalogWrapper={function(p:any){ return <div {...p}/> }} />
+}
+`,
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+		// Local const defined in render scope
+		{
+			code: `
+function Page(){
+  const Local = (p:any)=> <div {...p}/>;
+  return <AlgoliaLayout CatalogWrapper={Local} />
+}
+`,
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+		// useCallback in render
+		{
+			code: `
+import { useCallback } from 'react';
+function Page(){
+  const Local = useCallback((p:any)=> <div {...p}/>, []);
+  return <AlgoliaLayout CatalogWrapper={Local} />
+}
+`,
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+		// useMemo returning function
+		{
+			code: `
+import { useMemo } from 'react';
+function Page(){
+  const Local = useMemo(()=> (p:any)=> <div {...p}/>, []);
+  return <AlgoliaLayout CatalogWrapper={Local} />
+}
+`,
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+		// Passing inline wrapper in another component
+		{
+			code: `
+function ContentVerticalCarouselGrid({ header, ...gridProps }: any){
+  const CatalogWrapper = (props:any)=> <ContentCarouselWrapper {...props} {...gridProps} header={header} />;
+  return <AlgoliaLayout CatalogWrapper={CatalogWrapper} />
+}
+`,
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+		// Capitalized local component defined inside render
+		{
+			code: `
+function Teams(){
+  const TeamsCatalogWrapper = (p:any)=> <div {...p}/>;
+  return <AlgoliaLayout CatalogWrapper={TeamsCatalogWrapper} />
+}
+`,
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+		// Configured prop pattern *Component
+		{
+			code: `
+function Page(){
+  const X = (p:any)=> <div {...p}/>;
+  return <Layout ItemComponent={X} />
+}
+`,
+			options: [{ props: ['*Component'] }],
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+		// Should not be mistaken for render prop when allowRenderProps=true but prop matches configured
+		{
+			code: `
+function Page(){
+  return <Layout CatalogWrapper={(p:any)=> <div {...p}/>} />
+}
+`,
+			options: [{ allowRenderProps: true }],
+			errors: [{ messageId: 'noInlineComponentProp' }],
+		},
+	],
+});


### PR DESCRIPTION
Add `blumint/no-inline-component-prop` ESLint rule to prohibit passing inline function components to component-type props.

This rule prevents unnecessary React subtree remounts caused by unstable component identities, which can lead to visible UI flashes, performance regressions, and loss of internal component state.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dcb3964-6b51-4ef0-9da6-380d33dfb387">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4dcb3964-6b51-4ef0-9da6-380d33dfb387">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

