### PR TITLE
Implement eslint rule for boolean prefixes

### DIFF
--- a/docs/rules/no-misleading-boolean-prefixes.md
+++ b/docs/rules/no-misleading-boolean-prefixes.md
@@ -1,0 +1,66 @@
+### no-misleading-boolean-prefixes
+
+Reserve boolean-style prefixes like is, has, or should for functions that actually return boolean values. This maintains clarity and sets accurate expectations about a function's return type.
+
+- **Type**: problem
+- **Recommended**: error
+
+#### Why
+
+Boolean-style prefixes communicate that a function answers a yes/no question. If such functions return non-boolean values (like numbers, strings, or objects), it misleads readers and makes call sites harder to understand.
+
+#### Examples
+
+Bad:
+```javascript
+function isAvailable() {
+  return 'yes';
+}
+
+const hasItems = (arr) => arr.length;
+
+async function shouldRefresh() {
+  return 'false';
+}
+
+function isUser() {
+  return { id: 1 };
+}
+```
+
+Good:
+```javascript
+function isAvailable() {
+  return Math.random() > 0.5;
+}
+
+const hasItems = (arr) => arr.length > 0;
+
+async function shouldRefresh() {
+  const stale = await cache.isStale();
+  return stale === true;
+}
+
+function getUser() {
+  return { id: 1 };
+}
+```
+
+#### Allowed patterns
+
+- Type predicates (e.g., `function isUser(u): u is User { ... }`)
+- Explicit `boolean` return types or `Promise<boolean>` (and unions with `null`/`undefined`/`void`)
+- Obvious boolean expressions: comparisons (`>`, `===`), negations (`!x`, `!!x`), or `Boolean(x)`
+
+#### Options
+
+```json
+{
+  "@blumintinc/blumint/no-misleading-boolean-prefixes": [
+    "error",
+    { "prefixes": ["is", "has", "should"] }
+  ]
+}
+```
+
+- **prefixes**: string[] — prefixes considered boolean-like. Defaults to `["is", "has", "should"]`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,7 @@ import { noSeparateLoadingState } from './rules/no-separate-loading-state';
 import { optimizeObjectBooleanConditions } from './rules/optimize-object-boolean-conditions';
 import { preferParamsOverParentId } from './rules/prefer-params-over-parent-id';
 import { preferFieldPathsInTransforms } from './rules/prefer-field-paths-in-transforms';
+import { noMisleadingBooleanPrefixes } from './rules/no-misleading-boolean-prefixes';
 
 module.exports = {
   meta: {
@@ -265,6 +266,7 @@ module.exports = {
         '@blumintinc/blumint/optimize-object-boolean-conditions': 'error',
         '@blumintinc/blumint/prefer-params-over-parent-id': 'error',
         '@blumintinc/blumint/prefer-field-paths-in-transforms': 'warn',
+        '@blumintinc/blumint/no-misleading-boolean-prefixes': 'error',
       },
     },
   },
@@ -398,5 +400,6 @@ module.exports = {
     'optimize-object-boolean-conditions': optimizeObjectBooleanConditions,
     'prefer-params-over-parent-id': preferParamsOverParentId,
     'prefer-field-paths-in-transforms': preferFieldPathsInTransforms,
+    'no-misleading-boolean-prefixes': noMisleadingBooleanPrefixes,
   },
 };

--- a/src/rules/no-misleading-boolean-prefixes.ts
+++ b/src/rules/no-misleading-boolean-prefixes.ts
@@ -1,0 +1,332 @@
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/createRule';
+
+ type MessageIds = 'nonBooleanReturn';
+ type Options = [
+   {
+     prefixes?: string[];
+   },
+ ];
+
+ const DEFAULT_PREFIXES = ['is', 'has', 'should'];
+
+ function isUppercaseLetter(char: string): boolean {
+   return char >= 'A' && char <= 'Z';
+ }
+
+ function isDigit(char: string): boolean {
+   return char >= '0' && char <= '9';
+ }
+
+ function startsWithBooleanPrefix(name: string, prefixes: string[]): boolean {
+   if (!name) return false;
+   const lower = name.toLowerCase();
+   for (const prefix of prefixes) {
+     const p = prefix.toLowerCase();
+     if (lower.startsWith(p)) {
+       if (name.length === p.length) return true; // edge: exact match like "is"
+       const next = name[p.length];
+       if (isUppercaseLetter(next) || next === '_' || isDigit(next)) {
+         return true;
+       }
+     }
+   }
+   return false;
+ }
+
+ function isTsBooleanLike(typeNode: TSESTree.TypeNode | undefined): boolean {
+   if (!typeNode) return false;
+   if (typeNode.type === AST_NODE_TYPES.TSBooleanKeyword) return true;
+
+   // Allow unions like boolean | undefined | null | void
+   if (typeNode.type === AST_NODE_TYPES.TSUnionType) {
+     return typeNode.types.every((t) =>
+       t.type === AST_NODE_TYPES.TSBooleanKeyword ||
+       t.type === AST_NODE_TYPES.TSUndefinedKeyword ||
+       t.type === AST_NODE_TYPES.TSNullKeyword ||
+       t.type === AST_NODE_TYPES.TSVoidKeyword,
+     );
+   }
+
+   // Promise<boolean> (or Promise<boolean | undefined | null>)
+   if (
+     typeNode.type === AST_NODE_TYPES.TSTypeReference &&
+     typeNode.typeName.type === AST_NODE_TYPES.Identifier &&
+     typeNode.typeName.name === 'Promise' &&
+     typeNode.typeParameters?.params?.length
+   ) {
+     const inner = typeNode.typeParameters.params[0];
+     if (inner.type === AST_NODE_TYPES.TSBooleanKeyword) return true;
+     if (inner.type === AST_NODE_TYPES.TSUnionType) {
+       return inner.types.every((t) =>
+         t.type === AST_NODE_TYPES.TSBooleanKeyword ||
+         t.type === AST_NODE_TYPES.TSUndefinedKeyword ||
+         t.type === AST_NODE_TYPES.TSNullKeyword ||
+         t.type === AST_NODE_TYPES.TSVoidKeyword,
+       );
+     }
+   }
+
+   return false;
+ }
+
+ function isExpressionBooleanLike(expr: TSESTree.Expression): boolean | 'non' | 'unknown' {
+   switch (expr.type) {
+     case AST_NODE_TYPES.Literal:
+       return typeof expr.value === 'boolean' ? true : 'non';
+     case AST_NODE_TYPES.TemplateLiteral:
+       return 'non';
+     case AST_NODE_TYPES.ObjectExpression:
+     case AST_NODE_TYPES.ArrayExpression:
+     case AST_NODE_TYPES.NewExpression:
+     case AST_NODE_TYPES.ClassExpression:
+     case AST_NODE_TYPES.FunctionExpression:
+     case AST_NODE_TYPES.ArrowFunctionExpression:
+       return 'non';
+     case AST_NODE_TYPES.UnaryExpression:
+       if (expr.operator === '!') return true; // !x or !!x
+       if (expr.operator === 'void') return 'non';
+       return 'unknown';
+     case AST_NODE_TYPES.BinaryExpression: {
+       const cmp = ['===', '!==', '==', '!=', '>', '<', '>=', '<='];
+       return cmp.includes(expr.operator) ? true : 'unknown';
+     }
+     case AST_NODE_TYPES.LogicalExpression:
+       // && and || often return non-boolean operands; don't infer true
+       return 'unknown';
+     case AST_NODE_TYPES.MemberExpression: {
+       if (
+         expr.property.type === AST_NODE_TYPES.Identifier &&
+         expr.property.name === 'length'
+       ) {
+         return 'non';
+       }
+       return 'unknown';
+     }
+     case AST_NODE_TYPES.ConditionalExpression: {
+       const cons = isExpressionBooleanLike(expr.consequent);
+       const alt = isExpressionBooleanLike(expr.alternate);
+       if (cons === true && alt === true) return true;
+       if (cons === 'non' || alt === 'non') return 'non';
+       return 'unknown';
+     }
+     case AST_NODE_TYPES.CallExpression: {
+       if (expr.callee.type === AST_NODE_TYPES.Identifier && expr.callee.name === 'Boolean') {
+         return true;
+       }
+       return 'unknown';
+     }
+     case AST_NODE_TYPES.Identifier:
+       if (expr.name === 'undefined') return 'non';
+       return 'unknown';
+     case AST_NODE_TYPES.AwaitExpression:
+       return 'unknown';
+     default:
+       return 'unknown';
+   }
+ }
+
+ function getReturnTypeNode(node: TSESTree.FunctionLike): TSESTree.TypeNode | undefined {
+   if (node.returnType?.typeAnnotation) return node.returnType.typeAnnotation;
+   return undefined;
+ }
+
+ function hasTypePredicate(node: TSESTree.FunctionLike): boolean {
+   return (
+     node.returnType?.typeAnnotation?.type === AST_NODE_TYPES.TSTypePredicate
+   );
+ }
+
+ function collectReturnExpressions(fn: TSESTree.FunctionLike): TSESTree.Expression[] {
+   const results: TSESTree.Expression[] = [];
+   const visited = new Set<TSESTree.Node>();
+
+   function visit(n: TSESTree.Node | null | undefined) {
+     if (!n || visited.has(n)) return;
+     visited.add(n);
+
+     // Do not traverse into nested functions/classes
+     if (
+       n.type === AST_NODE_TYPES.FunctionDeclaration ||
+       n.type === AST_NODE_TYPES.FunctionExpression ||
+       n.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+       n.type === AST_NODE_TYPES.ClassDeclaration ||
+       n.type === AST_NODE_TYPES.ClassExpression
+     ) {
+       if (n === fn) {
+         // traverse this function's body
+         // continue
+       } else {
+         return;
+       }
+     }
+
+     if (n.type === AST_NODE_TYPES.ReturnStatement) {
+       if (n.argument && n.argument.type) {
+         results.push(n.argument as TSESTree.Expression);
+       } else {
+         // return; without value
+         // Represent as Identifier 'undefined' to treat as non-boolean
+         // We won't push undefined, but handle later by a flag
+         (results as any).noValueReturn = true;
+       }
+     }
+
+     for (const key of Object.keys(n)) {
+       if (key === 'parent' || key === 'range' || key === 'loc') continue;
+       const value: any = (n as any)[key];
+       if (!value) continue;
+       if (Array.isArray(value)) {
+         for (const child of value) {
+           if (child && typeof child === 'object' && 'type' in child) visit(child);
+         }
+       } else if (value && typeof value === 'object' && 'type' in value) {
+         visit(value);
+       }
+     }
+   }
+
+   if (fn.type === AST_NODE_TYPES.ArrowFunctionExpression && fn.expression) {
+     // expression-bodied arrow function: synthesize a return
+     const bodyExpr = fn.body as TSESTree.Expression;
+     results.push(bodyExpr);
+     return results;
+   }
+
+   if (fn.body && fn.body.type === AST_NODE_TYPES.BlockStatement) visit(fn.body);
+   return results;
+ }
+
+ export const noMisleadingBooleanPrefixes = createRule<Options, MessageIds>({
+   name: 'no-misleading-boolean-prefixes',
+   meta: {
+     type: 'problem',
+     docs: {
+       description:
+         'Reserve boolean-style prefixes (is/has/should) for functions that actually return boolean values.',
+       recommended: 'error',
+     },
+     schema: [
+       {
+         type: 'object',
+         properties: {
+           prefixes: {
+             type: 'array',
+             items: { type: 'string' },
+           },
+         },
+         additionalProperties: false,
+       },
+     ],
+     messages: {
+       nonBooleanReturn:
+         'Function "{{name}}" uses a boolean-style prefix but does not return a boolean value.',
+     },
+   },
+   defaultOptions: [{ prefixes: DEFAULT_PREFIXES }],
+   create(context, [options]) {
+     const prefixes = (options && options.prefixes) || DEFAULT_PREFIXES;
+
+     function shouldCheckName(name: string): boolean {
+       return startsWithBooleanPrefix(name, prefixes);
+     }
+
+     function report(node: TSESTree.Node, name: string) {
+       context.report({ node, messageId: 'nonBooleanReturn', data: { name } });
+     }
+
+     function checkFunctionLike(
+       node:
+         | TSESTree.FunctionDeclaration
+         | TSESTree.FunctionExpression
+         | TSESTree.ArrowFunctionExpression,
+       name: string,
+       reportNode: TSESTree.Node,
+     ) {
+       if (!shouldCheckName(name)) return;
+
+       // Type predicate allows boolean-like
+       if (hasTypePredicate(node)) return;
+
+       const typeNode = getReturnTypeNode(node);
+       if (typeNode) {
+         if (isTsBooleanLike(typeNode)) return;
+         // Explicit non-boolean annotation
+         report(reportNode, name);
+         return;
+       }
+
+       const returns = collectReturnExpressions(node);
+       const noValueReturn = (returns as any).noValueReturn === true;
+       if (noValueReturn) {
+         report(reportNode, name);
+         return;
+       }
+
+       if (returns.length === 0) {
+         // No returns implies void
+         report(reportNode, name);
+         return;
+       }
+
+       for (const expr of returns) {
+         const kind = isExpressionBooleanLike(expr);
+         if (kind === 'non') {
+           report(reportNode, name);
+           return;
+         }
+       }
+       // If we can't determine it's non-boolean, do not report to avoid false positives
+     }
+
+     return {
+       FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+         if (!node.id) return;
+         checkFunctionLike(node, node.id.name, node.id);
+       },
+       FunctionExpression(node: TSESTree.FunctionExpression) {
+         // Prefer variable declarator or method/property name
+         if (
+           node.parent?.type === AST_NODE_TYPES.VariableDeclarator &&
+           node.parent.id.type === AST_NODE_TYPES.Identifier
+         ) {
+           checkFunctionLike(node, node.parent.id.name, node.parent.id);
+           return;
+         }
+         // If part of a property or method, let dedicated visitors handle it to avoid duplicates
+         if (node.parent?.type === AST_NODE_TYPES.Property) return;
+         if (node.parent?.type === AST_NODE_TYPES.MethodDefinition) return;
+         if (node.id) {
+           checkFunctionLike(node, node.id.name, node.id);
+         }
+       },
+       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression) {
+         if (
+           node.parent?.type === AST_NODE_TYPES.VariableDeclarator &&
+           node.parent.id.type === AST_NODE_TYPES.Identifier
+         ) {
+           checkFunctionLike(node, node.parent.id.name, node.parent.id);
+           return;
+         }
+         // If part of a property, let the Property visitor handle it to avoid duplicates
+         if (node.parent?.type === AST_NODE_TYPES.Property) return;
+       },
+       MethodDefinition(node: TSESTree.MethodDefinition) {
+         if (node.key.type !== AST_NODE_TYPES.Identifier) return;
+         const name = node.key.name;
+         const fn = node.value;
+         if (fn.type === AST_NODE_TYPES.TSEmptyBodyFunctionExpression) return;
+         checkFunctionLike(fn, name, node.key);
+       },
+       Property(node: TSESTree.Property) {
+         if (node.key.type !== AST_NODE_TYPES.Identifier) return;
+         if (
+           node.value.type === AST_NODE_TYPES.FunctionExpression ||
+           node.value.type === AST_NODE_TYPES.ArrowFunctionExpression
+         ) {
+           checkFunctionLike(node.value, node.key.name, node.key);
+         }
+       },
+     };
+   },
+ });

--- a/src/tests/no-misleading-boolean-prefixes.test.ts
+++ b/src/tests/no-misleading-boolean-prefixes.test.ts
@@ -1,0 +1,113 @@
+import { ruleTesterTs } from '../utils/ruleTester';
+import { noMisleadingBooleanPrefixes } from '../rules/no-misleading-boolean-prefixes';
+
+ruleTesterTs.run('no-misleading-boolean-prefixes', noMisleadingBooleanPrefixes, {
+  valid: [
+    // Simple boolean returns
+    'function isAvailable() { return true; }',
+    'const hasItems = (arr: any[]) => arr.length > 0;',
+    'async function shouldRefresh() { return Math.random() > 0.5; }',
+
+    // Type predicate
+    'function isUser(u: unknown): u is { id: number } { return !!(u as any)?.id; }',
+
+    // Explicit boolean annotations
+    'const isEnabled = (): boolean => false;',
+    'async function hasAccess(): Promise<boolean> { return true; }',
+
+    // Class method with boolean return
+    'class C { isReady(): boolean { return false; } }',
+
+    // Object method
+    'const o = { isOk(): boolean { return true; } }',
+    'const o2 = { isOk: (): boolean => true }',
+
+    // Boolean-likely expressions
+    'const isEmpty = (arr: any[]) => !arr.length;',
+    'const isZero = (n: number) => n === 0;',
+    'const isPositive = (n: number) => n > 0;',
+    'const isTruthy = (x: any) => Boolean(x);',
+    'const isFlag = (x: any) => true ? true : false;',
+
+    // Async arrow returns boolean (Promise<boolean>)
+    'const shouldRun = async () => true;',
+
+    // Boundary checks to avoid false positives
+    'function issueTracker() { return "ok"; }',
+    'function isometricScale() { return 123; }',
+    'function hashtagCount() { return 1; }',
+    'function shoulderedWeight() { return "lbs"; }',
+
+    // Allow underscore boundary if returns boolean
+    'const is_ready = () => true;',
+
+    // Promise<boolean | undefined>
+    'async function hasToken(): Promise<boolean | undefined> { return true; }',
+  ],
+  invalid: [
+    // Examples from spec
+    {
+      code: 'function isAvailable() { return "yes"; }',
+      errors: [{ messageId: 'nonBooleanReturn' }],
+    },
+    {
+      code: 'const hasItems = (arr) => arr.length;',
+      errors: [{ messageId: 'nonBooleanReturn' }],
+    },
+    {
+      code: 'async function shouldRefresh() { return "false"; }',
+      errors: [{ messageId: 'nonBooleanReturn' }],
+    },
+    {
+      code: 'function isUser() { return { id: 1 }; }',
+      errors: [{ messageId: 'nonBooleanReturn' }],
+    },
+
+    // Explicit non-boolean annotations
+    {
+      code: 'const isEnabled: () => string = () => "yes";',
+      errors: [{ messageId: 'nonBooleanReturn' }],
+    },
+    {
+      code: 'async function hasAccess(): Promise<string> { return "ok"; }',
+      errors: [{ messageId: 'nonBooleanReturn' }],
+    },
+
+    // Arrow with clearly non-boolean expressions
+    {
+      code: 'const isEmpty = (arr) => arr.length;',
+      errors: [{ messageId: 'nonBooleanReturn' }],
+    },
+    { code: 'const hasData = () => ({})', errors: [{ messageId: 'nonBooleanReturn' }] },
+    { code: 'const hasList = () => []', errors: [{ messageId: 'nonBooleanReturn' }] },
+    { code: 'const isNow = () => new Date()', errors: [{ messageId: 'nonBooleanReturn' }] },
+    { code: 'const hasName = () => `name`', errors: [{ messageId: 'nonBooleanReturn' }] },
+
+    // No return -> void
+    { code: 'function isActive() { }', errors: [{ messageId: 'nonBooleanReturn' }] },
+
+    // return; without value
+    { code: 'function hasValue() { return; }', errors: [{ messageId: 'nonBooleanReturn' }] },
+
+    // null/undefined
+    { code: 'function isNullish() { return null; }', errors: [{ messageId: 'nonBooleanReturn' }] },
+    { code: 'function hasNothing() { return undefined; }', errors: [{ messageId: 'nonBooleanReturn' }] },
+
+    // Class method
+    { code: 'class K { isDone() { return "done"; } }', errors: [{ messageId: 'nonBooleanReturn' }] },
+
+    // Object method
+    { code: 'const obj = { hasUser() { return 1; } }', errors: [{ messageId: 'nonBooleanReturn' }] },
+    { code: 'const obj2 = { hasUser: () => 1 }', errors: [{ messageId: 'nonBooleanReturn' }] },
+
+    // Underscore boundary with non-boolean
+    { code: 'const is_ready = () => 1;', errors: [{ messageId: 'nonBooleanReturn' }] },
+
+    // Uppercase leading name
+    { code: 'function ISReady() { return 1; }', errors: [{ messageId: 'nonBooleanReturn' }] },
+
+    // Union with non-boolean types should fail
+    { code: 'function hasConfig(): boolean | number { return 1 as any; }', errors: [{ messageId: 'nonBooleanReturn' }] },
+    { code: 'async function shouldClear(): Promise<boolean | string> { return true; }', errors: [{ messageId: 'nonBooleanReturn' }] },
+  ],
+});


### PR DESCRIPTION
Add `no-misleading-boolean-prefixes` ESLint rule to ensure functions with boolean-style prefixes (`is`, `has`, `should`) return boolean values, improving code clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-f55bee64-f47c-4f46-bba8-5763b5be7875">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f55bee64-f47c-4f46-bba8-5763b5be7875">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

