### PR TITLE
Fix ESLint rule for default arguments in React components

### DIFF
--- a/src/rules/enforce-global-constants.ts
+++ b/src/rules/enforce-global-constants.ts
@@ -1,7 +1,8 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, TSESTree, TSESLint } from '@typescript-eslint/utils';
 import { createRule } from '../utils/createRule';
+import { ASTHelpers } from '../utils/ASTHelpers';
 
-type MessageIds = 'useGlobalConstant';
+type MessageIds = 'useGlobalConstant' | 'extractDefaultToGlobalConstant';
 
 export const enforceGlobalConstants = createRule<[], MessageIds>({
   name: 'enforce-global-constants',
@@ -9,20 +10,176 @@ export const enforceGlobalConstants = createRule<[], MessageIds>({
     type: 'suggestion',
     docs: {
       description:
-        'Enforce using global static constants instead of useMemo with empty dependency arrays for object literals',
+        'Enforce using global static constants instead of useMemo with empty dependency arrays for object literals, and extract inline destructuring defaults in React components/hooks to global constants',
       recommended: 'error',
     },
+    fixable: 'code',
     schema: [],
     messages: {
       useGlobalConstant:
         'Use a global static constant instead of useMemo with an empty dependency array for object literals',
+      extractDefaultToGlobalConstant:
+        'Extract inline default value to a module-level constant for stable reference',
     },
   },
   defaultOptions: [],
   create(context) {
+    const sourceCode = context.getSourceCode();
+
+    function isHookName(name: string): boolean {
+      return name.startsWith('use') && name[3]?.toUpperCase() === name[3];
+    }
+
+    function isComponentOrHookFunction(
+      fn: TSESTree.FunctionDeclaration | TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+    ): boolean {
+      if (fn.type === AST_NODE_TYPES.FunctionDeclaration) {
+        const n = fn.id?.name ?? '';
+        return /^[A-Z]/.test(n) || isHookName(n);
+      }
+      const parent = fn.parent;
+      if (
+        parent &&
+        parent.type === AST_NODE_TYPES.VariableDeclarator &&
+        parent.id.type === AST_NODE_TYPES.Identifier
+      ) {
+        const n = parent.id.name;
+        return /^[A-Z]/.test(n) || isHookName(n);
+      }
+      return false;
+    }
+
+    function getEnclosingFunction(node: TSESTree.Node):
+      | TSESTree.FunctionDeclaration
+      | TSESTree.ArrowFunctionExpression
+      | TSESTree.FunctionExpression
+      | null {
+      let current: TSESTree.Node | undefined | null = node;
+      while (current) {
+        if (
+          current.type === AST_NODE_TYPES.FunctionDeclaration ||
+          current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          current.type === AST_NODE_TYPES.FunctionExpression
+        ) {
+          return current;
+        }
+        current = current.parent as TSESTree.Node | undefined | null;
+      }
+      return null;
+    }
+
+    function toUpperSnakeCase(name: string): string {
+      return name.replace(/([A-Z])/g, '_$1').toUpperCase().replace(/^_/, '');
+    }
+
+    function collectAssignmentDefaultsFromPattern(
+      pattern:
+        | TSESTree.ArrayPattern
+        | TSESTree.ObjectPattern
+        | TSESTree.AssignmentPattern,
+    ) {
+      const results: Array<{
+        assignment: TSESTree.AssignmentPattern;
+        localName: string;
+      }> = [];
+      const visitPattern = (
+        p:
+          | TSESTree.ArrayPattern
+          | TSESTree.ObjectPattern
+          | TSESTree.AssignmentPattern,
+      ) => {
+        if (p.type === AST_NODE_TYPES.ObjectPattern) {
+          for (const prop of p.properties) {
+            if (prop.type === AST_NODE_TYPES.Property) {
+              const value = prop.value as unknown as
+                | TSESTree.ArrayPattern
+                | TSESTree.ObjectPattern
+                | TSESTree.AssignmentPattern
+                | TSESTree.Identifier;
+              if (
+                value &&
+                (value as TSESTree.AssignmentPattern).type ===
+                  AST_NODE_TYPES.AssignmentPattern
+              ) {
+                const assign = value as TSESTree.AssignmentPattern;
+                const left = assign.left;
+                if (left.type === AST_NODE_TYPES.Identifier) {
+                  results.push({ assignment: assign, localName: left.name });
+                }
+                if (
+                  left.type === AST_NODE_TYPES.ObjectPattern ||
+                  left.type === AST_NODE_TYPES.ArrayPattern
+                ) {
+                  // Nested pattern on the left of an assignment; uncommon, ignore naming
+                }
+              } else if (
+                value &&
+                (value as TSESTree.ObjectPattern | TSESTree.ArrayPattern).type &&
+                ((value as TSESTree.ObjectPattern | TSESTree.ArrayPattern).type ===
+                  AST_NODE_TYPES.ObjectPattern ||
+                  (value as TSESTree.ObjectPattern | TSESTree.ArrayPattern).type ===
+                    AST_NODE_TYPES.ArrayPattern)
+              ) {
+                visitPattern(
+                  value as TSESTree.ObjectPattern | TSESTree.ArrayPattern,
+                );
+              }
+            }
+          }
+        } else if (p.type === AST_NODE_TYPES.ArrayPattern) {
+          for (const elem of p.elements) {
+            if (!elem) continue;
+            if (elem.type === AST_NODE_TYPES.AssignmentPattern) {
+              const left = elem.left;
+              if (left.type === AST_NODE_TYPES.Identifier) {
+                results.push({ assignment: elem, localName: left.name });
+              }
+            } else if (
+              elem.type === AST_NODE_TYPES.ArrayPattern ||
+              elem.type === AST_NODE_TYPES.ObjectPattern
+            ) {
+              visitPattern(elem);
+            }
+          }
+        } else if (p.type === AST_NODE_TYPES.AssignmentPattern) {
+          const left = p.left;
+          if (left.type === AST_NODE_TYPES.Identifier) {
+            results.push({ assignment: p, localName: left.name });
+          }
+        }
+      };
+      visitPattern(pattern);
+      return results;
+    }
+
+    function hasIdentifiers(node: TSESTree.Expression | null): boolean {
+      return ASTHelpers.declarationIncludesIdentifier(node as unknown as TSESTree.Node);
+    }
+
+    function alreadyHasConst(program: TSESTree.Program, constName: string): boolean {
+      for (const stmt of program.body) {
+        if (
+          stmt.type === AST_NODE_TYPES.VariableDeclaration &&
+          stmt.kind === 'const'
+        ) {
+          for (const d of stmt.declarations) {
+            if (d.id.type === AST_NODE_TYPES.Identifier && d.id.name === constName) {
+              return true;
+            }
+          }
+        }
+      }
+      return false;
+    }
+
+    function buildConstDeclarationLine(constName: string, initText: string): string {
+      const needsAsConst = /^(?:true|false|\d|\[|\{|[`'"])/.test(initText) && !/\bas const\b/.test(initText);
+      const initializer = needsAsConst ? `${initText} as const` : initText;
+      return `const ${constName} = ${initializer};`;
+    }
+
     return {
       CallExpression(node) {
-        // Check if it's a useMemo call
         if (
           node.callee.type !== AST_NODE_TYPES.Identifier ||
           node.callee.name !== 'useMemo'
@@ -30,12 +187,10 @@ export const enforceGlobalConstants = createRule<[], MessageIds>({
           return;
         }
 
-        // Check if it has exactly two arguments
         if (node.arguments.length !== 2) {
           return;
         }
 
-        // Check if the second argument is an empty array
         const depsArray = node.arguments[1];
         if (
           depsArray.type !== AST_NODE_TYPES.ArrayExpression ||
@@ -44,18 +199,14 @@ export const enforceGlobalConstants = createRule<[], MessageIds>({
           return;
         }
 
-        // Check if the first argument is an arrow function
         const callback = node.arguments[0];
         if (callback.type !== AST_NODE_TYPES.ArrowFunctionExpression) {
           return;
         }
 
-        // Check if the arrow function body is a block statement with a return statement
-        // or a direct expression (implicit return)
         let returnValue: TSESTree.Expression | null = null;
 
         if (callback.body.type === AST_NODE_TYPES.BlockStatement) {
-          // If it's a block, find the return statement
           const returnStatement = callback.body.body.find(
             (stmt) => stmt.type === AST_NODE_TYPES.ReturnStatement,
           ) as TSESTree.ReturnStatement | undefined;
@@ -66,17 +217,14 @@ export const enforceGlobalConstants = createRule<[], MessageIds>({
 
           returnValue = returnStatement.argument;
         } else {
-          // If it's an expression (implicit return)
           returnValue = callback.body;
         }
 
-        // Handle 'as const' type assertions
         let actualReturnValue = returnValue;
         if (returnValue.type === AST_NODE_TYPES.TSAsExpression) {
           actualReturnValue = returnValue.expression;
         }
 
-        // Check if the return value is an object literal or an array of object literals
         if (
           actualReturnValue.type === AST_NODE_TYPES.ObjectExpression ||
           (actualReturnValue.type === AST_NODE_TYPES.ArrayExpression &&
@@ -91,6 +239,122 @@ export const enforceGlobalConstants = createRule<[], MessageIds>({
             messageId: 'useGlobalConstant',
           });
         }
+      },
+
+      VariableDeclaration(node) {
+        const relevantDeclarators = node.declarations.filter(
+          (d) =>
+            d.id.type === AST_NODE_TYPES.ObjectPattern ||
+            d.id.type === AST_NODE_TYPES.ArrayPattern,
+        );
+        if (relevantDeclarators.length === 0) return;
+
+        const enclosingFn = getEnclosingFunction(node);
+        if (!enclosingFn || !isComponentOrHookFunction(enclosingFn)) return;
+
+        const defaults: Array<{
+          assignment: TSESTree.AssignmentPattern;
+          localName: string;
+        }> = [];
+        for (const d of relevantDeclarators) {
+          defaults.push(
+            ...collectAssignmentDefaultsFromPattern(
+              d.id as TSESTree.ObjectPattern | TSESTree.ArrayPattern,
+            ),
+          );
+        }
+        if (defaults.length === 0) return;
+
+        const staticDefaults = defaults.filter((def) => {
+          const right = def.assignment.right as TSESTree.Expression | null;
+          return right && !hasIdentifiers(right);
+        });
+        if (staticDefaults.length === 0) return;
+
+        context.report({
+          node,
+          messageId: 'extractDefaultToGlobalConstant',
+          fix(fixer) {
+            const fixes: TSESLint.RuleFix[] = [];
+
+            const programNode = sourceCode.ast;
+            const declLines: string[] = [];
+
+            for (const def of staticDefaults) {
+              const { assignment, localName } = def;
+              const right = assignment.right as TSESTree.Expression;
+              const rightText = sourceCode.getText(right);
+              const constName = `DEFAULT_${toUpperSnakeCase(localName)}`;
+
+              if (!alreadyHasConst(programNode, constName)) {
+                declLines.push(buildConstDeclarationLine(constName, rightText));
+              }
+
+              fixes.push(fixer.replaceText(right, constName));
+            }
+
+            if (declLines.length > 0) {
+              const program = sourceCode.ast;
+              const imports = program.body.filter(
+                (s) => s.type === AST_NODE_TYPES.ImportDeclaration,
+              );
+              if (imports.length > 0) {
+                const lastImport = imports[imports.length - 1];
+                const rest = declLines.slice(1).join('\n');
+                const block = `\n${declLines[0]}\n\n${rest ? rest + '\n\n' : ''}`;
+
+                // Remove whitespace after the last import up to the next node (if any)
+                const body = program.body;
+                const idx = body.findIndex((s) => s === lastImport);
+                const next = body[idx + 1];
+                if (next) {
+                  fixes.unshift(fixer.replaceTextRange([lastImport.range[1], next.range[0]], ''));
+                }
+                fixes.unshift(
+                  fixer.insertTextAfter(
+                    lastImport,
+                    block,
+                  ),
+                );
+              } else {
+                // No imports. If a directive prologue exists (e.g., 'use client'), insert after it; otherwise insert at file start.
+                const body = program.body;
+                let directiveEnd = 0;
+                for (let i = 0; i < body.length; i++) {
+                  const stmt = body[i];
+                  if (
+                    stmt.type === AST_NODE_TYPES.ExpressionStatement &&
+                    stmt.expression.type === AST_NODE_TYPES.Literal &&
+                    typeof stmt.expression.value === 'string'
+                  ) {
+                    directiveEnd = i + 1;
+                  } else {
+                    break;
+                  }
+                }
+                const rest = declLines.slice(1).join('\n');
+                const block = `\n${declLines[0]}\n\n${rest ? rest + '\n\n' : ''}`;
+                if (directiveEnd > 0) {
+                  const lastDirective = body[directiveEnd - 1];
+                  const nextNode = body[directiveEnd];
+                  if (nextNode) {
+                    fixes.unshift(
+                      fixer.replaceTextRange(
+                        [lastDirective.range[1], nextNode.range[0]],
+                        '',
+                      ),
+                    );
+                  }
+                  fixes.unshift(fixer.insertTextAfter(lastDirective, block));
+                } else {
+                  fixes.unshift(fixer.insertTextBeforeRange([0, 0], block));
+                }
+              }
+            }
+
+            return fixes;
+          },
+        });
       },
     };
   },

--- a/src/tests/enforce-global-constants.test.ts
+++ b/src/tests/enforce-global-constants.test.ts
@@ -49,6 +49,28 @@ ruleTesterJsx.run('enforce-global-constants', enforceGlobalConstants, {
       return <div>{expensiveComputation}</div>;
     };
     `,
+    // Destructuring defaults that depend on identifiers should not be auto-extracted
+    `
+    const MyComponent = () => {
+      const base = { a: 1 };
+      const { options = base } = props;
+      return <div/>;
+    };
+    `,
+    // Non component scope destructuring defaults are valid
+    `
+    function helper() {
+      const { threshold = 5 } = config;
+      return threshold;
+    }
+    `,
+    // Hook with no defaults
+    `
+    export const useSomething = ({ a, b }: { a?: number; b?: number }) => {
+      const { a: a1, b: b1 } = { a, b };
+      return { a1, b1 };
+    };
+    `,
   ],
   invalid: [
     // useMemo with empty dependency array returning object literal
@@ -122,6 +144,280 @@ ruleTesterJsx.run('enforce-global-constants', enforceGlobalConstants, {
           messageId: 'useGlobalConstant',
         },
       ],
+    },
+    // Extract object default from destructuring in component
+    {
+      code: `
+export const useQuerySelector = <TElement extends HTMLElement>({
+  query,
+  ...options
+}: UseQuerySelectorProps) => {
+  const {
+    root,
+    observeOptions = { childList: true, subtree: true },
+    debounceMs = 10,
+    shouldStopOnFound = false,
+  } = options;
+  return { root, observeOptions, debounceMs, shouldStopOnFound };
+};
+      `,
+      output: `
+const DEFAULT_OBSERVE_OPTIONS = { childList: true, subtree: true } as const;
+
+const DEFAULT_DEBOUNCE_MS = 10 as const;
+const DEFAULT_SHOULD_STOP_ON_FOUND = false as const;
+
+
+export const useQuerySelector = <TElement extends HTMLElement>({
+  query,
+  ...options
+}: UseQuerySelectorProps) => {
+  const {
+    root,
+    observeOptions = DEFAULT_OBSERVE_OPTIONS,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    shouldStopOnFound = DEFAULT_SHOULD_STOP_ON_FOUND,
+  } = options;
+  return { root, observeOptions, debounceMs, shouldStopOnFound };
+};
+      `,
+      errors: [
+        { messageId: 'extractDefaultToGlobalConstant' },
+      ],
+    },
+    // Extract array default and primitive defaults
+    {
+      code: `
+      const MyComponent = () => {
+        const { list = [1,2,3], size = 20, flag = true } = props;
+        return <div/>;
+      };
+      `,
+      output: `
+const DEFAULT_LIST = [1,2,3] as const;
+
+const DEFAULT_SIZE = 20 as const;
+const DEFAULT_FLAG = true as const;
+
+
+      const MyComponent = () => {
+        const { list = DEFAULT_LIST, size = DEFAULT_SIZE, flag = DEFAULT_FLAG } = props;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Should skip defaults that reference identifiers, but still extract static ones
+    {
+      code: `
+      const MyComponent = () => {
+        const base = { a: 1 };
+        const { a = base.a, b = 2, c = { x: 1 } } = props;
+        return <div/>;
+      };
+      `,
+      output: `
+const DEFAULT_B = 2 as const;
+
+const DEFAULT_C = { x: 1 } as const;
+
+
+      const MyComponent = () => {
+        const base = { a: 1 };
+        const { a = base.a, b = DEFAULT_B, c = DEFAULT_C } = props;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Nested destructuring with defaults
+    {
+      code: `
+      function MyComponent(){
+        const { a: { x = 1 }, b = { y: 2 } } = props;
+        return <div/>;
+      }
+      `,
+      output: `
+const DEFAULT_X = 1 as const;
+
+const DEFAULT_B = { y: 2 } as const;
+
+
+      function MyComponent(){
+        const { a: { x = DEFAULT_X }, b = DEFAULT_B } = props;
+        return <div/>;
+      }
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Defaults inside hooks
+    {
+      code: `
+      export const useThing = ({ opts, n }: { opts?: any; n?: number }) => {
+        const { opts: options = { stable: true }, n: count = 3 } = { opts, n };
+        return { options, count };
+      };
+      `,
+      output: `
+const DEFAULT_OPTIONS = { stable: true } as const;
+
+const DEFAULT_COUNT = 3 as const;
+
+
+      export const useThing = ({ opts, n }: { opts?: any; n?: number }) => {
+        const { opts: options = DEFAULT_OPTIONS, n: count = DEFAULT_COUNT } = { opts, n };
+        return { options, count };
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Multiple declarations in one statement
+    {
+      code: `
+      const MyComponent = () => {
+        const { a = 1 } = props, { b = { z: 9 } } = props;
+        return <div/>;
+      };
+      `,
+      output: `
+const DEFAULT_A = 1 as const;
+
+const DEFAULT_B = { z: 9 } as const;
+
+
+      const MyComponent = () => {
+        const { a = DEFAULT_A } = props, { b = DEFAULT_B } = props;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Insert after directive prologue
+    {
+      code: `
+      'use client';
+
+      const C = () => {
+        const { a = { k: 1 } } = props;
+        return <div/>;
+      };
+      `,
+      output: `
+      'use client';
+const DEFAULT_A = { k: 1 } as const;
+
+const C = () => {
+        const { a = DEFAULT_A } = props;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Insert after imports
+    {
+      code: `
+      import React from 'react';
+      import x from './x';
+
+      const C = () => {
+        const { a = [1,2], b = 'hi' } = props;
+        return <div/>;
+      };
+      `,
+      output: `
+      import React from 'react';
+      import x from './x';
+const DEFAULT_A = [1,2] as const;
+
+const DEFAULT_B = 'hi' as const;
+
+const C = () => {
+        const { a = DEFAULT_A, b = DEFAULT_B } = props;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Reuse existing constant if present
+    {
+      code: `
+      const DEFAULT_FLAG = false as const;
+      const C = () => {
+        const { ok = false, flag = DEFAULT_FLAG } = props;
+        return <div/>;
+      };
+      `,
+      output: `
+const DEFAULT_OK = false as const;
+
+
+      const DEFAULT_FLAG = false as const;
+      const C = () => {
+        const { ok = DEFAULT_OK, flag = DEFAULT_FLAG } = props;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // ArrayPattern defaults
+    {
+      code: `
+      const Comp = () => {
+        const [a = {x:1}, b = 2] = arr;
+        return <div/>;
+      };
+      `,
+      output: `
+const DEFAULT_A = {x:1} as const;
+
+const DEFAULT_B = 2 as const;
+
+
+      const Comp = () => {
+        const [a = DEFAULT_A, b = DEFAULT_B] = arr;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Aliased property names
+    {
+      code: `
+      const Comp = () => {
+        const { longPropertyName: lp = { deep: true } } = props;
+        return <div/>;
+      };
+      `,
+      output: `
+const DEFAULT_LP = { deep: true } as const;
+
+
+      const Comp = () => {
+        const { longPropertyName: lp = DEFAULT_LP } = props;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
+    },
+    // Inline as const should not duplicate as const
+    {
+      code: `
+      const Comp = () => {
+        const { conf = ({ a: 1 } as const) } = props;
+        return <div/>;
+      };
+      `,
+      output: `
+const DEFAULT_CONF = { a: 1 } as const;
+
+
+      const Comp = () => {
+        const { conf = (DEFAULT_CONF) } = props;
+        return <div/>;
+      };
+      `,
+      errors: [{ messageId: 'extractDefaultToGlobalConstant' }],
     },
   ],
 });


### PR DESCRIPTION
Extract inline destructuring default values in React component/hook bodies to global constants to prevent unnecessary re-renders.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8972488-5a1c-4226-84f3-34749c462dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8972488-5a1c-4226-84f3-34749c462dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Lint rule now detects inline default values in destructuring within React components/hooks and offers an autofix to extract them into module-level constants for stable references.
  - Autofix inserts constants in the appropriate place, preserves formatting, and avoids creating duplicates.
  - Only default values are replaced; existing behavior for memoization with empty dependencies remains unchanged.
- Chores
  - Rule marked as fixable and includes an additional user-facing message to guide applying the new autofix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->