### PR TITLE
Improve eslint rule for microdiff equality checks

### DIFF
--- a/src/rules/fast-deep-equal-over-microdiff.ts
+++ b/src/rules/fast-deep-equal-over-microdiff.ts
@@ -28,59 +28,242 @@ export const fastDeepEqualOverMicrodiff = createRule<[], MessageIds>({
     let microdiffImportName = 'diff';
     let fastDeepEqualImportName = 'isEqual';
     const reportedNodes = new Set<TSESTree.Node>();
+    let plannedFastDeepEqualImport = false;
+
+    /**
+     * Resolve an identifier to its variable and return the initializer CallExpression if it's a microdiff call.
+     */
+    function resolveIdentifierToMicrodiffCall(
+      identifier: TSESTree.Identifier,
+    ): TSESTree.CallExpression | undefined {
+      // Look for a reference in the current scope chain
+      let scope: any = context.getScope();
+      let variable: any | undefined;
+      while (scope && !variable) {
+        variable = scope.variables.find((v: any) => v.name === identifier.name);
+        scope = scope.upper;
+      }
+      if (!variable) return undefined;
+      const defNode = variable.defs[0]?.node as any;
+      if (!defNode) return undefined;
+
+      // Variable declarator with initializer call
+      if (
+        defNode.type === AST_NODE_TYPES.VariableDeclarator &&
+        defNode.init &&
+        defNode.init.type === AST_NODE_TYPES.CallExpression &&
+        defNode.init.callee &&
+        defNode.init.callee.type === AST_NODE_TYPES.Identifier &&
+        defNode.init.callee.name === microdiffImportName
+      ) {
+        return defNode.init as TSESTree.CallExpression;
+      }
+      return undefined;
+    }
+
+    /**
+     * Determine if the given variable is used only for `.length` property accesses.
+     * If there is any non-length usage (e.g., indexing, iteration, method calls), return false.
+     */
+    function isVariableOnlyUsedForLength(identifier: TSESTree.Identifier): boolean {
+      // Walk up scope chain to find a reference for this identifier
+      let scope: any = context.getScope();
+      let variable: any | undefined;
+      while (scope && !variable) {
+        variable = scope.variables.find((v: any) => v.name === identifier.name);
+        scope = scope.upper;
+      }
+      if (!variable) return false;
+
+      // All references must be strictly of the form <id>.length, except the variable's own declaration
+      return variable.references.every((reference: any) => {
+        const idNode = reference.identifier as TSESTree.Identifier;
+        const parent = idNode.parent as TSESTree.Node | undefined;
+        if (!parent) return false;
+
+        // Allow the declaration id (not considered a read)
+        if (
+          parent.type === AST_NODE_TYPES.VariableDeclarator &&
+          (parent.id as any) === idNode
+        ) {
+          return true;
+        }
+
+        // Accept only the specific pattern: Identifier used as object in MemberExpression with property `length`
+        if (
+          parent.type === AST_NODE_TYPES.MemberExpression &&
+          parent.object === idNode &&
+          !parent.computed &&
+          parent.property.type === AST_NODE_TYPES.Identifier &&
+          parent.property.name === 'length'
+        ) {
+          return true;
+        }
+        return false;
+      });
+    }
+
+    /**
+     * If a MemberExpression is `<something>.length`, returns the underlying microdiff call if applicable.
+     * Supports direct `diff(a,b).length` and `changes.length` where `changes` is initialized to a microdiff call.
+     */
+    function getMicrodiffCallFromLengthAccess(
+      member: TSESTree.MemberExpression,
+    ): { diffCall?: TSESTree.CallExpression; viaIdentifier: boolean } {
+      if (
+        member.property.type !== AST_NODE_TYPES.Identifier ||
+        member.property.name !== 'length'
+      ) {
+        return { viaIdentifier: false };
+      }
+
+      const obj = member.object as TSESTree.Node;
+      if (
+        obj.type === AST_NODE_TYPES.CallExpression &&
+        obj.callee.type === AST_NODE_TYPES.Identifier &&
+        obj.callee.name === microdiffImportName
+      ) {
+        return { diffCall: obj, viaIdentifier: false };
+      }
+
+      if (obj.type === AST_NODE_TYPES.Identifier) {
+        const resolved = resolveIdentifierToMicrodiffCall(obj);
+        if (!resolved) return { viaIdentifier: true };
+
+        // Ensure the identifier is only used for `.length` accesses (no content-based usage)
+        if (!isVariableOnlyUsedForLength(obj)) {
+          return { viaIdentifier: true };
+        }
+        return { diffCall: resolved, viaIdentifier: true };
+      }
+
+      return { viaIdentifier: false };
+    }
 
     /**
      * Check if a node is a microdiff equality check pattern
      * Looks for patterns like:
      * - diff(a, b).length === 0
-     * - diff(a, b).length !== 0
+     * - 0 === diff(a, b).length
+     * - changes.length === 0 (where `changes = diff(a,b)` and changes is only used for length checks)
+     * - changes.length !== 0
      * - !diff(a, b).length
+     * - !changes.length
      */
     function isMicrodiffEqualityCheck(node: TSESTree.Node): {
       isEquality: boolean;
       diffCall?: TSESTree.CallExpression;
     } {
-      // Check for binary expressions like diff(a, b).length === 0
-      if (
-        node.type === AST_NODE_TYPES.BinaryExpression &&
-        (node.operator === '===' ||
-          node.operator === '==' ||
-          node.operator === '!==' ||
-          node.operator === '!=') &&
-        node.right.type === AST_NODE_TYPES.Literal &&
-        node.right.value === 0 &&
-        node.left.type === AST_NODE_TYPES.MemberExpression &&
-        node.left.property.type === AST_NODE_TYPES.Identifier &&
-        node.left.property.name === 'length' &&
-        node.left.object.type === AST_NODE_TYPES.CallExpression &&
-        node.left.object.callee.type === AST_NODE_TYPES.Identifier &&
-        node.left.object.callee.name === microdiffImportName
-      ) {
-        return {
-          isEquality: node.operator === '===' || node.operator === '==',
-          diffCall: node.left.object,
-        };
+      // Check for binary expressions comparing length to 0 (both directions)
+      if (node.type === AST_NODE_TYPES.BinaryExpression) {
+        const operators = ['===', '==', '!==', '!='] as const;
+        if (operators.includes(node.operator as any)) {
+          // side A: MemberExpression .length, side B: 0
+          if (
+            node.right.type === AST_NODE_TYPES.Literal &&
+            node.right.value === 0 &&
+            node.left.type === AST_NODE_TYPES.MemberExpression
+          ) {
+            const { diffCall } = getMicrodiffCallFromLengthAccess(node.left);
+            if (diffCall) {
+              return {
+                isEquality: node.operator === '===' || node.operator === '==',
+                diffCall,
+              };
+            }
+          }
+          // side A: 0, side B: MemberExpression .length
+          if (
+            node.left.type === AST_NODE_TYPES.Literal &&
+            node.left.value === 0 &&
+            node.right.type === AST_NODE_TYPES.MemberExpression
+          ) {
+            const { diffCall } = getMicrodiffCallFromLengthAccess(node.right);
+            if (diffCall) {
+              return {
+                isEquality: node.operator === '===' || node.operator === '==',
+                diffCall,
+              };
+            }
+          }
+        }
       }
 
-      // Check for unary expressions like !diff(a, b).length
+      // Check for unary expressions like !diff(a, b).length or !changes.length
       if (
         node.type === AST_NODE_TYPES.UnaryExpression &&
-        node.operator === '!' &&
-        node.argument.type === AST_NODE_TYPES.MemberExpression &&
-        node.argument.property.type === AST_NODE_TYPES.Identifier &&
-        node.argument.property.name === 'length' &&
-        node.argument.object.type === AST_NODE_TYPES.CallExpression &&
-        node.argument.object.callee.type === AST_NODE_TYPES.Identifier &&
-        node.argument.object.callee.name === microdiffImportName
+        node.operator === '!'
       ) {
-        return {
-          isEquality: true, // !diff(...).length is equivalent to diff(...).length === 0
-          diffCall: node.argument.object,
-        };
+        if (node.argument.type === AST_NODE_TYPES.MemberExpression) {
+          const { diffCall } = getMicrodiffCallFromLengthAccess(node.argument);
+          if (diffCall) {
+            return {
+              isEquality: true, // !<expr>.length is equivalent to <expr>.length === 0
+              diffCall,
+            };
+          }
+        }
       }
 
       // Not a microdiff equality check
       return { isEquality: false };
+    }
+
+    /**
+     * Try to find the identifier used as `<id>.length` for the given equality node
+     */
+    function getLengthIdentifierFromNode(
+      node: TSESTree.Node,
+    ): TSESTree.Identifier | undefined {
+      if (node.type === AST_NODE_TYPES.BinaryExpression) {
+        const left = node.left;
+        const right = node.right;
+        const isLengthMember = (n: TSESTree.Node): n is TSESTree.MemberExpression =>
+          n.type === AST_NODE_TYPES.MemberExpression &&
+          !n.computed &&
+          n.property.type === AST_NODE_TYPES.Identifier &&
+          n.property.name === 'length';
+        if (isLengthMember(left) && left.object.type === AST_NODE_TYPES.Identifier) {
+          return left.object;
+        }
+        if (isLengthMember(right) && right.object.type === AST_NODE_TYPES.Identifier) {
+          return right.object;
+        }
+      }
+      if (node.type === AST_NODE_TYPES.UnaryExpression) {
+        const arg = node.argument;
+        if (
+          arg.type === AST_NODE_TYPES.MemberExpression &&
+          !arg.computed &&
+          arg.property.type === AST_NODE_TYPES.Identifier &&
+          arg.property.name === 'length' &&
+          arg.object.type === AST_NODE_TYPES.Identifier
+        ) {
+          return arg.object;
+        }
+      }
+      return undefined;
+    }
+
+    /**
+     * Get the indentation at the start of the current line for a node
+     */
+    function getLineBaseIndent(node: TSESTree.Node): string {
+      const text = sourceCode.text as string;
+      const start = node.range![0];
+      const lineStart = text.lastIndexOf('\n', start - 1) + 1;
+      let i = lineStart;
+      let indent = '';
+      while (i < text.length) {
+        const ch = text[i];
+        if (ch === ' ' || ch === '\t') {
+          indent += ch;
+          i++;
+        } else {
+          break;
+        }
+      }
+      return indent;
     }
 
     /**
@@ -101,40 +284,95 @@ export const fastDeepEqualOverMicrodiff = createRule<[], MessageIds>({
       const arg1 = sourceCode.getText(args[0]);
       const arg2 = sourceCode.getText(args[1]);
 
-      // If fast-deep-equal is not imported, we need to add the import after the microdiff import
-      if (!hasFastDeepEqualImport) {
-        // Find the end of the microdiff import statement
+      const fixes: any[] = [];
+
+      // Add import if needed (only once across all fixes in this file)
+      if (!hasFastDeepEqualImport && !plannedFastDeepEqualImport) {
         const importDeclarations = sourceCode.ast.body.filter(
           (node): node is TSESTree.ImportDeclaration =>
             node.type === AST_NODE_TYPES.ImportDeclaration,
         );
-
         const microdiffImport = importDeclarations.find(
           (node) => node.source.value === 'microdiff',
         );
-
-        const importFix = fixer.insertTextAfter(
-          microdiffImport!,
-          `\nimport isEqual from 'fast-deep-equal';`,
-        );
-
-        const replaceFix = fixer.replaceText(
-          node,
-          isEquality
-            ? `isEqual(${arg1}, ${arg2})`
-            : `!isEqual(${arg1}, ${arg2})`,
-        );
-
-        return [importFix, replaceFix];
+        if (microdiffImport) {
+          fixes.push(
+            fixer.insertTextAfter(
+              microdiffImport,
+              `\nimport isEqual from 'fast-deep-equal';`,
+            ),
+          );
+          plannedFastDeepEqualImport = true;
+        }
       }
 
-      // Otherwise just replace the expression
-      return fixer.replaceText(
-        node,
-        isEquality
-          ? `${fastDeepEqualImportName}(${arg1}, ${arg2})`
-          : `!${fastDeepEqualImportName}(${arg1}, ${arg2})`,
-      );
+      // If the equality was via an identifier like `changes.length`, and that identifier
+      // is declared as `const changes = diff(...);` and used ONLY for `.length` checks,
+      // remove the redundant variable declaration.
+      const maybeIdentifier = getLengthIdentifierFromNode(node);
+      if (maybeIdentifier && isVariableOnlyUsedForLength(maybeIdentifier)) {
+        // Resolve the definition
+        let scope: any = context.getScope();
+        let variable: any | undefined;
+        while (scope && !variable) {
+          variable = scope.variables.find(
+            (v: any) => v.name === maybeIdentifier.name,
+          );
+          scope = scope.upper;
+        }
+        const defNode = variable?.defs?.[0]?.node as TSESTree.VariableDeclarator;
+        if (
+          defNode &&
+          defNode.type === AST_NODE_TYPES.VariableDeclarator &&
+          defNode.parent &&
+          defNode.parent.type === AST_NODE_TYPES.VariableDeclaration
+        ) {
+          const declaration = defNode.parent;
+          if (declaration.declarations.length === 1) {
+            const start = declaration.range[0];
+            const end = declaration.range[1];
+            const text = sourceCode.text as string;
+            let removalStart = start;
+            const prevNewline = text.lastIndexOf('\n', start - 1);
+            removalStart = prevNewline >= 0 ? prevNewline + 1 : 0;
+            let removalEnd = end;
+            if (text[removalEnd] === '\r' && text[removalEnd + 1] === '\n') {
+              removalEnd += 2;
+            } else if (text[removalEnd] === '\n') {
+              removalEnd += 1;
+            }
+            fixes.push(fixer.removeRange([removalStart, removalEnd]));
+          }
+        }
+      }
+
+      // Replace the equality expression with isEqual call
+      const isMultilineCall =
+        diffCall.loc &&
+        args[0].loc &&
+        (diffCall.loc.start.line !== args[0].loc.start.line ||
+          (args[1] && args[0].loc.start.line !== args[1].loc.start.line));
+
+      let replacement: string;
+      if (isMultilineCall) {
+        const baseIndent = getLineBaseIndent(node);
+        const innerIndentPlus = baseIndent + '  ';
+        replacement =
+          `${fastDeepEqualImportName}(` +
+          `\n${innerIndentPlus}${arg1},` +
+          `\n${innerIndentPlus}${arg2},` +
+          `\n${baseIndent})`;
+      } else {
+        replacement = `${fastDeepEqualImportName}(${arg1}, ${arg2})`;
+      }
+
+      if (!isEquality) {
+        replacement = `!${replacement}`;
+      }
+
+      fixes.push(fixer.replaceText(node, replacement));
+
+      return fixes;
     }
 
     return {
@@ -150,6 +388,9 @@ export const fastDeepEqualOverMicrodiff = createRule<[], MessageIds>({
               specifier.type === AST_NODE_TYPES.ImportSpecifier &&
               specifier.imported.name === 'diff'
             ) {
+              microdiffImportName = specifier.local.name;
+            }
+            if (specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier) {
               microdiffImportName = specifier.local.name;
             }
           });

--- a/src/rules/fast-deep-equal-over-microdiff.ts
+++ b/src/rules/fast-deep-equal-over-microdiff.ts
@@ -33,75 +33,77 @@ export const fastDeepEqualOverMicrodiff = createRule<[], MessageIds>({
     /**
      * Resolve an identifier to its variable and return the initializer CallExpression if it's a microdiff call.
      */
-    function resolveIdentifierToMicrodiffCall(
-      identifier: TSESTree.Identifier,
-    ): TSESTree.CallExpression | undefined {
-      // Look for a reference in the current scope chain
-      let scope: any = context.getScope();
-      let variable: any | undefined;
-      while (scope && !variable) {
-        variable = scope.variables.find((v: any) => v.name === identifier.name);
-        scope = scope.upper;
-      }
-      if (!variable) return undefined;
-      const defNode = variable.defs[0]?.node as any;
-      if (!defNode) return undefined;
+function findVariableInScopeChain(
+  identifier: TSESTree.Identifier,
+): any | undefined {
+  let scope: any = context.getScope();
+  let variable: any | undefined;
+  while (scope && !variable) {
+    variable = scope.variables.find((v: any) => v.name === identifier.name);
+    scope = scope.upper;
+  }
+  return variable;
+}
 
-      // Variable declarator with initializer call
-      if (
-        defNode.type === AST_NODE_TYPES.VariableDeclarator &&
-        defNode.init &&
-        defNode.init.type === AST_NODE_TYPES.CallExpression &&
-        defNode.init.callee &&
-        defNode.init.callee.type === AST_NODE_TYPES.Identifier &&
-        defNode.init.callee.name === microdiffImportName
-      ) {
-        return defNode.init as TSESTree.CallExpression;
-      }
-      return undefined;
+function resolveIdentifierToMicrodiffCall(
+  identifier: TSESTree.Identifier,
+): TSESTree.CallExpression | undefined {
+  // Look for a reference in the current scope chain
+  const variable = findVariableInScopeChain(identifier);
+  if (!variable) return undefined;
+  const defNode = variable.defs[0]?.node as any;
+  if (!defNode) return undefined;
+
+  // Variable declarator with initializer call
+  if (
+    defNode.type === AST_NODE_TYPES.VariableDeclarator &&
+    defNode.init &&
+    defNode.init.type === AST_NODE_TYPES.CallExpression &&
+    defNode.init.callee &&
+    defNode.init.callee.type === AST_NODE_TYPES.Identifier &&
+    defNode.init.callee.name === microdiffImportName
+  ) {
+    return defNode.init as TSESTree.CallExpression;
+  }
+  return undefined;
+}
+
+/**
+ * Determine if the given variable is used only for `.length` property accesses.
+ * If there is any non-length usage (e.g., indexing, iteration, method calls), return false.
+ */
+function isVariableOnlyUsedForLength(identifier: TSESTree.Identifier): boolean {
+  // Walk up scope chain to find a reference for this identifier
+  const variable = findVariableInScopeChain(identifier);
+  if (!variable) return false;
+
+  // All references must be strictly of the form <id>.length, except the variable's own declaration
+  return variable.references.every((reference: any) => {
+    const idNode = reference.identifier as TSESTree.Identifier;
+    const parent = idNode.parent as TSESTree.Node | undefined;
+    if (!parent) return false;
+
+    // Allow the declaration id (not considered a read)
+    if (
+      parent.type === AST_NODE_TYPES.VariableDeclarator &&
+      (parent.id as any) === idNode
+    ) {
+      return true;
     }
 
-    /**
-     * Determine if the given variable is used only for `.length` property accesses.
-     * If there is any non-length usage (e.g., indexing, iteration, method calls), return false.
-     */
-    function isVariableOnlyUsedForLength(identifier: TSESTree.Identifier): boolean {
-      // Walk up scope chain to find a reference for this identifier
-      let scope: any = context.getScope();
-      let variable: any | undefined;
-      while (scope && !variable) {
-        variable = scope.variables.find((v: any) => v.name === identifier.name);
-        scope = scope.upper;
-      }
-      if (!variable) return false;
-
-      // All references must be strictly of the form <id>.length, except the variable's own declaration
-      return variable.references.every((reference: any) => {
-        const idNode = reference.identifier as TSESTree.Identifier;
-        const parent = idNode.parent as TSESTree.Node | undefined;
-        if (!parent) return false;
-
-        // Allow the declaration id (not considered a read)
-        if (
-          parent.type === AST_NODE_TYPES.VariableDeclarator &&
-          (parent.id as any) === idNode
-        ) {
-          return true;
-        }
-
-        // Accept only the specific pattern: Identifier used as object in MemberExpression with property `length`
-        if (
-          parent.type === AST_NODE_TYPES.MemberExpression &&
-          parent.object === idNode &&
-          !parent.computed &&
-          parent.property.type === AST_NODE_TYPES.Identifier &&
-          parent.property.name === 'length'
-        ) {
-          return true;
-        }
-        return false;
-      });
+    // Accept only the specific pattern: Identifier used as object in MemberExpression with property `length`
+    if (
+      parent.type === AST_NODE_TYPES.MemberExpression &&
+      parent.object === idNode &&
+      !parent.computed &&
+      parent.property.type === AST_NODE_TYPES.Identifier &&
+      parent.property.name === 'length'
+    ) {
+      return true;
     }
+    return false;
+  });
+}
 
     /**
      * If a MemberExpression is `<something>.length`, returns the underlying microdiff call if applicable.

--- a/src/tests/fast-deep-equal-over-microdiff.test.ts
+++ b/src/tests/fast-deep-equal-over-microdiff.test.ts
@@ -60,6 +60,38 @@ function hasConfigChanged(oldConfig, newConfig) {
   return diff(oldConfig, newConfig).length > 0;
 }`,
     },
+    // Do not flag when variable is used beyond length equality (for-of)
+    {
+      code: `import diff from 'microdiff';
+
+function processChanges(a, b) {
+  const changes = diff(a, b);
+  const isEqual = changes.length === 0;
+  for (const change of changes) {
+    if (change.type === 'CREATE') return false;
+  }
+  return isEqual;
+}`,
+    },
+    // Do not flag when comparing to non-zero literal
+    {
+      code: `import diff from 'microdiff';
+
+function hasOneChange(a, b) {
+  const changes = diff(a, b);
+  return changes.length === 1;
+}`,
+    },
+    // Do not flag when variable is reassigned later
+    {
+      code: `import diff from 'microdiff';
+
+function maybeEqual(a, b) {
+  let changes = diff(a, b);
+  changes = [];
+  return changes.length === 0;
+}`,
+    },
   ],
   invalid: [
     // Using microdiff for equality check with .length === 0
@@ -232,6 +264,119 @@ import deepEqual from 'fast-deep-equal';
 
 function areObjectsEqual(obj1, obj2) {
   return deepEqual(obj1, obj2);
+}`,
+    },
+    // Default import of microdiff, direct inline equality
+    {
+      code: `import diff from 'microdiff';
+
+function areObjectsEqual(a, b) {
+  return diff(a, b).length === 0;
+}`,
+      errors: [{ messageId: 'useFastDeepEqual' }],
+      output: `import diff from 'microdiff';
+import isEqual from 'fast-deep-equal';
+
+function areObjectsEqual(a, b) {
+  return isEqual(a, b);
+}`,
+    },
+    // Variable assignment with arbitrary name, then equality check
+    {
+      code: `import diff from 'microdiff';
+
+function areObjectsEqual(a, b) {
+  const changes = diff(a, b);
+  return changes.length === 0;
+}`,
+      errors: [{ messageId: 'useFastDeepEqual' }],
+      output: `import diff from 'microdiff';
+import isEqual from 'fast-deep-equal';
+
+function areObjectsEqual(a, b) {
+  return isEqual(a, b);
+}`,
+    },
+    // Variable assignment with different name, used in if condition
+    {
+      code: `import diff from 'microdiff';
+
+function doSomething(before, after) {
+  const differences = diff(before, after);
+  if (differences.length === 0) {
+    return;
+  }
+}`,
+      errors: [{ messageId: 'useFastDeepEqual' }],
+      output: `import diff from 'microdiff';
+import isEqual from 'fast-deep-equal';
+
+function doSomething(before, after) {
+  if (isEqual(before, after)) {
+    return;
+  }
+}`,
+    },
+    // Unary usage on variable: !changes.length
+    {
+      code: `import diff from 'microdiff';
+
+function areSame(x, y) {
+  const changes = diff(x, y);
+  return !changes.length;
+}`,
+      errors: [{ messageId: 'useFastDeepEqual' }],
+      output: `import diff from 'microdiff';
+import isEqual from 'fast-deep-equal';
+
+function areSame(x, y) {
+  return isEqual(x, y);
+}`,
+    },
+    // Symmetric literal comparison: 0 === diff(...).length
+    {
+      code: `import diff from 'microdiff';
+
+function eq(a, b) {
+  return 0 === diff(a, b).length;
+}`,
+      errors: [{ messageId: 'useFastDeepEqual' }],
+      output: `import diff from 'microdiff';
+import isEqual from 'fast-deep-equal';
+
+function eq(a, b) {
+  return isEqual(a, b);
+}`,
+    },
+    // Multiple occurrences in the same file should add a single import
+    {
+      code: `import diff from 'microdiff';
+
+function checkAll(prevData, newData, previousMetadataRef, newMetadata) {
+  const changesData = diff({ ...prevData }, { ...newData });
+  const isDataEqual = changesData.length === 0;
+
+  const changesMetadata = diff(
+    { ...previousMetadataRef.current },
+    { ...newMetadata },
+  );
+  const isMetadataEqual = changesMetadata.length === 0;
+
+  return isDataEqual && isMetadataEqual;
+}`,
+      errors: [{ messageId: 'useFastDeepEqual' }, { messageId: 'useFastDeepEqual' }],
+      output: `import diff from 'microdiff';
+import isEqual from 'fast-deep-equal';
+
+function checkAll(prevData, newData, previousMetadataRef, newMetadata) {
+  const isDataEqual = isEqual({ ...prevData }, { ...newData });
+
+  const isMetadataEqual = isEqual(
+    { ...previousMetadataRef.current },
+    { ...newMetadata },
+  );
+
+  return isDataEqual && isMetadataEqual;
 }`,
     },
   ],


### PR DESCRIPTION
Enhance `fast-deep-equal-over-microdiff` ESLint rule to detect and auto-fix all `microdiff(...).length === 0` patterns for improved efficiency.

The rule previously failed to flag `microdiff` usage when its result was assigned to a variable (e.g., `const changes = diff(a, b); return changes.length === 0;`) or used in inline unary expressions (`!diff(a, b).length`). This update ensures all such equality-only patterns are correctly identified and replaced with `fast-deep-equal`, including handling variable declarations and symmetric comparisons, while also preventing false positives where the diff content is genuinely used.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ae7f3c9-f2f7-4df8-b77e-ec549cff2b56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ae7f3c9-f2f7-4df8-b77e-ec549cff2b56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Expands lint rule to detect and autofix more microdiff-based equality patterns (including negations, either-side zero comparisons, and variable/alias forms) and replace them with fast-deep-equal, across expressions, conditionals, and returns.
  - Generates multiline-aware, correctly parenthesized fixes and inserts a single isEqual import when needed.

- Bug Fixes
  - Prevents duplicate imports and removes variables used only for length checks.

- Refactor
  - Improves identifier/alias resolution and fix aggregation to enable safer, broader autofix coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->