### PR TITLE
Fix eslint rule missing fixable property and expand tests

### DIFF
--- a/src/rules/enforce-dynamic-firebase-imports.ts
+++ b/src/rules/enforce-dynamic-firebase-imports.ts
@@ -10,6 +10,7 @@ export const enforceFirebaseImports = createRule({
         'Enforce dynamic importing for modules within the firebaseCloud directory to optimize initial bundle size. This ensures Firebase-related code is only loaded when needed, improving application startup time and reducing the main bundle size.',
       recommended: 'error',
     },
+    fixable: 'code',
     schema: [],
     messages: {
       noDynamicImport:
@@ -20,7 +21,7 @@ export const enforceFirebaseImports = createRule({
   create(context) {
     return {
       ImportDeclaration(node) {
-        // Skip type-only imports
+        // Skip type-only import declarations
         if (node.importKind === 'type') {
           return;
         }
@@ -28,28 +29,119 @@ export const enforceFirebaseImports = createRule({
         const importPath = node.source.value as string;
 
         // Check if the import is from firebaseCloud directory
-        if (importPath.includes('firebaseCloud/')) {
-          context.report({
-            node,
-            messageId: 'noDynamicImport',
-            fix(fixer) {
-              const importSpecifiers = node.specifiers
-                .filter((spec) => spec.type === 'ImportSpecifier')
-                .map(
-                  (spec) => (spec as TSESTree.ImportSpecifier).imported.name,
-                );
+        if (!importPath.includes('firebaseCloud/')) {
+          return;
+        }
 
-              if (importSpecifiers.length === 0) {
-                return null;
+        // Determine specifiers
+        const defaultSpecifier = node.specifiers.find(
+          (spec): spec is TSESTree.ImportDefaultSpecifier =>
+            spec.type === 'ImportDefaultSpecifier',
+        );
+        const namespaceSpecifier = node.specifiers.find(
+          (spec): spec is TSESTree.ImportNamespaceSpecifier =>
+            spec.type === 'ImportNamespaceSpecifier',
+        );
+        const namedSpecifiers = node.specifiers.filter(
+          (spec): spec is TSESTree.ImportSpecifier =>
+            spec.type === 'ImportSpecifier' && spec.importKind !== 'type',
+        );
+        const typeOnlySpecifiers = node.specifiers.filter(
+          (spec): spec is TSESTree.ImportSpecifier =>
+            spec.type === 'ImportSpecifier' && spec.importKind === 'type',
+        );
+
+        // If there are only type-only specifiers, allow
+        if (
+          !defaultSpecifier &&
+          !namespaceSpecifier &&
+          namedSpecifiers.length === 0 &&
+          typeOnlySpecifiers.length > 0
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'noDynamicImport',
+          fix(fixer) {
+            const statements: string[] = [];
+
+            // Preserve type-only specifiers by keeping a type import
+            if (typeOnlySpecifiers.length > 0) {
+              const typeNames = typeOnlySpecifiers
+                .map((spec) => {
+                  const importedName = spec.imported.name;
+                  const localName = spec.local.name;
+                  return importedName === localName
+                    ? importedName
+                    : `${importedName} as ${localName}`;
+                })
+                .join(', ');
+              statements.push(
+                `import type { ${typeNames} } from '${importPath}';`,
+              );
+            }
+
+            // When namespace import exists
+            if (namespaceSpecifier) {
+              const nsLocal = namespaceSpecifier.local.name;
+              statements.push(`const ${nsLocal} = await import('${importPath}');`);
+              // If default is also requested, assign from namespace
+              if (defaultSpecifier) {
+                const defLocal = defaultSpecifier.local.name;
+                statements.push(`const ${defLocal} = ${nsLocal}.default;`);
+              }
+              // If named value specifiers also exist, destructure from namespace
+              if (namedSpecifiers.length > 0) {
+                const destructureParts = namedSpecifiers.map((spec) => {
+                  const imported = spec.imported.name;
+                  const local = spec.local.name;
+                  return imported === local ? imported : `${imported}: ${local}`;
+                });
+                statements.push(
+                  `const { ${destructureParts.join(', ')} } = ${nsLocal};`,
+                );
               }
 
-              const destructuredImports = `{ ${importSpecifiers.join(', ')} }`;
-              const dynamicImport = `const ${destructuredImports} = await import('${importPath}');`;
+              // Return the combined replacement
+              return fixer.replaceText(node, statements.join(' '));
+            }
 
-              return fixer.replaceText(node, dynamicImport);
-            },
-          });
-        }
+            // Build destructuring-based dynamic import when default or named imports exist
+            const destructureParts: string[] = [];
+
+            if (defaultSpecifier) {
+              const defLocal = defaultSpecifier.local.name;
+              destructureParts.push(`default: ${defLocal}`);
+            }
+
+            if (namedSpecifiers.length > 0) {
+              for (const spec of namedSpecifiers) {
+                const imported = spec.imported.name;
+                const local = spec.local.name;
+                destructureParts.push(
+                  imported === local ? imported : `${imported}: ${local}`,
+                );
+              }
+            }
+
+            if (destructureParts.length > 0) {
+              statements.push(
+                `const { ${destructureParts.join(', ')} } = await import('${importPath}');`,
+              );
+              return fixer.replaceText(node, statements.join(' '));
+            }
+
+            // Side-effect import (no specifiers): convert to awaited dynamic import
+            if (node.specifiers.length === 0) {
+              return fixer.replaceText(node, `await import('${importPath}');`);
+            }
+
+            // If nothing can be fixed safely, do not provide a fix
+            return null;
+          },
+        });
       },
     };
   },

--- a/src/tests/enforce-dynamic-firebase-imports.test.ts
+++ b/src/tests/enforce-dynamic-firebase-imports.test.ts
@@ -1,138 +1,155 @@
-import { ESLintUtils } from '@typescript-eslint/utils';
+import { ruleTesterTs } from '../utils/ruleTester';
 import { enforceFirebaseImports } from '../rules/enforce-dynamic-firebase-imports';
 
-const ruleTester = new ESLintUtils.RuleTester({
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 2020,
-    sourceType: 'module',
-  },
-});
+const ruleTester = ruleTesterTs;
 
-describe('enforce-dynamic-firebase-imports', () => {
-  beforeAll(() => {
-    // Create a mock rule tester that doesn't throw
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    jest.spyOn(ruleTester, 'run').mockImplementation(() => {});
-  });
-
-  afterAll(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('should allow type imports from firebaseCloud', () => {
-    const code = `import type { Params } from '../../../../firebaseCloud/messaging/setGroupChannel';`;
-    expect(() => {
-      ruleTester.run(
-        'enforce-dynamic-firebase-imports',
-        enforceFirebaseImports as any,
-        {
-          valid: [{ code }],
-          invalid: [],
-        },
-      );
-    }).not.toThrow();
-  });
-
-  it('should allow regular imports from other directories', () => {
-    const code = `import { someFunction } from '../../../../otherDirectory/messaging/someFile';`;
-    expect(() => {
-      ruleTester.run(
-        'enforce-dynamic-firebase-imports',
-        enforceFirebaseImports as any,
-        {
-          valid: [{ code }],
-          invalid: [],
-        },
-      );
-    }).not.toThrow();
-  });
-
-  it('should allow framework imports', () => {
-    const code = `import { initializeApp } from 'firebase/app';`;
-    expect(() => {
-      ruleTester.run(
-        'enforce-dynamic-firebase-imports',
-        enforceFirebaseImports as any,
-        {
-          valid: [{ code }],
-          invalid: [],
-        },
-      );
-    }).not.toThrow();
-  });
-
-  it('should allow dynamic imports from firebaseCloud', () => {
-    const code = `const { setGroupChannel } = await import('../../../../firebaseCloud/messaging/setGroupChannel');`;
-    expect(() => {
-      ruleTester.run(
-        'enforce-dynamic-firebase-imports',
-        enforceFirebaseImports as any,
-        {
-          valid: [{ code }],
-          invalid: [],
-        },
-      );
-    }).not.toThrow();
-  });
-
-  it('should report static imports from firebaseCloud', () => {
-    const code = `import { setChannelGroup } from '../../../../firebaseCloud/messaging/setGroupChannel';`;
-    expect(() => {
-      ruleTester.run(
-        'enforce-dynamic-firebase-imports',
-        enforceFirebaseImports as any,
-        {
-          valid: [],
-          invalid: [
-            {
-              code,
-              errors: [{ messageId: 'noDynamicImport' }],
-              output: `const { setChannelGroup } = await import('../../../../firebaseCloud/messaging/setGroupChannel');`,
-            },
-          ],
-        },
-      );
-    }).not.toThrow();
-  });
-
-  it('should report mixed static and type imports from firebaseCloud', () => {
-    const code = `import { setChannelGroup, Params } from '../../../../firebaseCloud/messaging/setGroupChannel';`;
-    expect(() => {
-      ruleTester.run(
-        'enforce-dynamic-firebase-imports',
-        enforceFirebaseImports as any,
-        {
-          valid: [],
-          invalid: [
-            {
-              code,
-              errors: [{ messageId: 'noDynamicImport' }],
-              output: `const { setChannelGroup, Params } = await import('../../../../firebaseCloud/messaging/setGroupChannel');`,
-            },
-          ],
-        },
-      );
-    }).not.toThrow();
-  });
-
-  it('should report static imports with relative paths to firebaseCloud', () => {
-    const code = `import { helper } from '../../../../../src/firebaseCloud/utils/helper';`;
-    expect(() => {
-      ruleTester.run(
-        'enforce-dynamic-firebase-imports',
-        enforceFirebaseImports as any,
-        {
-          valid: [],
-          invalid: [
-            {
-              code,
-              errors: [{ messageId: 'noDynamicImport' }],
-              output: `const { helper } = await import('../../../../../src/firebaseCloud/utils/helper');`,
-            },
-          ],
-        },
-      );
-    }).not.toThrow();
-  });
+ruleTester.run('enforce-dynamic-firebase-imports', enforceFirebaseImports as any, {
+  valid: [
+    // Type-only import from firebaseCloud is allowed
+    {
+      code: `import type { Params } from '../../../../firebaseCloud/messaging/setGroupChannel';`,
+    },
+    // Type-only import using inline type keyword on specifier
+    {
+      code: `import { type Params } from '../../../../firebaseCloud/messaging/setGroupChannel';`,
+    },
+    // Type-only with alias
+    {
+      code: `import { type Params as P } from '../../../../firebaseCloud/messaging/setGroupChannel';`,
+    },
+    // Regular imports from other directories are allowed
+    {
+      code: `import { someFunction } from '../../../../otherDirectory/messaging/someFile';`,
+    },
+    // Framework imports are not targeted by this rule
+    {
+      code: `import { initializeApp } from 'firebase/app';`,
+    },
+    // Dynamic imports from firebaseCloud are allowed
+    {
+      code: `const { setGroupChannel } = await import('../../../../firebaseCloud/messaging/setGroupChannel');`,
+    },
+    // Path that contains "firebaseCloud" but not followed by a slash should not match
+    {
+      code: `import { helper } from '../../../../firebaseClouds/utils/helper';`,
+    },
+    // All specifiers are type-only
+    {
+      code: `import { type A, type B as BB } from '../../../../firebaseCloud/utils/types';`,
+    },
+  ],
+  invalid: [
+    // Single named import
+    {
+      code: `import { setChannelGroup } from '../../../../firebaseCloud/messaging/setGroupChannel';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { setChannelGroup } = await import('../../../../firebaseCloud/messaging/setGroupChannel');`,
+    },
+    // Multiple named imports
+    {
+      code: `import { a, b } from '../../../../firebaseCloud/messaging/mod';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { a, b } = await import('../../../../firebaseCloud/messaging/mod');`,
+    },
+    // Named import with alias
+    {
+      code: `import { a as A } from '../../../../firebaseCloud/messaging/mod';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { a: A } = await import('../../../../firebaseCloud/messaging/mod');`,
+    },
+    // Multiple named with alias
+    {
+      code: `import { a as A, b, c as C } from '../../../../firebaseCloud/messaging/mod';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { a: A, b, c: C } = await import('../../../../firebaseCloud/messaging/mod');`,
+    },
+    // Default import only
+    {
+      code: `import helper from '../../../../firebaseCloud/utils/helper';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { default: helper } = await import('../../../../firebaseCloud/utils/helper');`,
+    },
+    // Default + named
+    {
+      code: `import helper, { a, b as B } from '../../../../firebaseCloud/utils/helper';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { default: helper, a, b: B } = await import('../../../../firebaseCloud/utils/helper');`,
+    },
+    // Namespace import only
+    {
+      code: `import * as helper from '../../../../firebaseCloud/utils/helper';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const helper = await import('../../../../firebaseCloud/utils/helper');`,
+    },
+    // Default + namespace import
+    {
+      code: `import def, * as helper from '../../../../firebaseCloud/utils/helper';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const helper = await import('../../../../firebaseCloud/utils/helper'); const def = helper.default;`,
+    },
+    // Side-effect import
+    {
+      code: `import '../../../../firebaseCloud/utils/helper';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `await import('../../../../firebaseCloud/utils/helper');`,
+    },
+    // Mixed type and named (preserve type-only import)
+    {
+      code: `import { type Params, setChannelGroup as set } from '../../../../firebaseCloud/messaging/setGroupChannel';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output:
+        `import type { Params } from '../../../../firebaseCloud/messaging/setGroupChannel'; const { setChannelGroup: set } = await import('../../../../firebaseCloud/messaging/setGroupChannel');`,
+    },
+    // Mixed type (alias) and named (alias)
+    {
+      code: `import { type X as TX, a as A, b } from '../../../../firebaseCloud/messaging/mod';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output:
+        `import type { X as TX } from '../../../../firebaseCloud/messaging/mod'; const { a: A, b } = await import('../../../../firebaseCloud/messaging/mod');`,
+    },
+    // Mixed type-only and default
+    {
+      code: `import def, { type T } from '../../../../firebaseCloud/utils/helper';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output:
+        `import type { T } from '../../../../firebaseCloud/utils/helper'; const { default: def } = await import('../../../../firebaseCloud/utils/helper');`,
+    },
+    // Mixed type-only, default, and named
+    {
+      code: `import def, { type T, a as A } from '../../../../firebaseCloud/utils/helper';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output:
+        `import type { T } from '../../../../firebaseCloud/utils/helper'; const { default: def, a: A } = await import('../../../../firebaseCloud/utils/helper');`,
+    },
+    // Relative path variant to firebaseCloud
+    {
+      code: `import { helper } from '../../../../../src/firebaseCloud/utils/helper';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { helper } = await import('../../../../../src/firebaseCloud/utils/helper');`,
+    },
+    // Multiline static imports should be collapsed appropriately
+    {
+      code: `import {\n  a,\n  b as B\n} from '../../../../firebaseCloud/messaging/mod';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { a, b: B } = await import('../../../../firebaseCloud/messaging/mod');`,
+    },
+    // Ensure no change for specifier order (including aliasing)
+    {
+      code: `import { z as Z, a, m as M } from '../../../../firebaseCloud/messaging/alpha';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const { z: Z, a, m: M } = await import('../../../../firebaseCloud/messaging/alpha');`,
+    },
+    // Namespace import from src path
+    {
+      code: `import * as cloud from 'src/firebaseCloud/messaging/api';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const cloud = await import('src/firebaseCloud/messaging/api');`,
+    },
+    // Default + namespace from src path
+    {
+      code: `import def, * as cloud from 'src/firebaseCloud/messaging/api';`,
+      errors: [{ messageId: 'noDynamicImport' }],
+      output: `const cloud = await import('src/firebaseCloud/messaging/api'); const def = cloud.default;`,
+    },
+  ],
 });


### PR DESCRIPTION
Add `meta.fixable` and enhance the fixer for `enforce-dynamic-firebase-imports` to resolve ESLint errors and correctly convert all static `firebaseCloud` imports.

The ESLint error "Fixable rules must set the `meta.fixable` property" occurred because the rule provided auto-fixes without declaring `meta.fixable`. While adding this property fixes the immediate error, the rule's fixer was also significantly enhanced to robustly handle various import types (default, namespace, named with aliases, side-effect, and mixed value/type specifiers) while preserving type-only imports, which are not subject to dynamic loading. The expanded test suite now covers these complex scenarios to ensure the fix is comprehensive.

---
<a href="https://cursor.com/background-agent?bcId=bc-824c12c1-9f50-423c-b943-f70e64aba0a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-824c12c1-9f50-423c-b943-f70e64aba0a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

