### PR TITLE
Fix eslint enforce-memoize-async rule for async methods

### DIFF
--- a/src/rules/enforce-memoize-async.ts
+++ b/src/rules/enforce-memoize-async.ts
@@ -24,6 +24,7 @@ export const enforceMemoizeAsync = createRule<Options, MessageIds>({
   create(context) {
     let hasMemoizeImport = false;
     let memoizeAlias = 'Memoize';
+    let scheduledImportFix = false;
 
     return {
       ImportDeclaration(node) {
@@ -57,32 +58,77 @@ export const enforceMemoizeAsync = createRule<Options, MessageIds>({
           return;
         }
 
-        // Check if method already has @Memoize decorator
+        // Check if method already has @Memoize or @Memoize() decorator
         const hasDecorator = node.decorators?.some((decorator) => {
-          if (decorator.expression.type !== AST_NODE_TYPES.CallExpression) {
-            return false;
+          const expr = decorator.expression as any;
+          // @Memoize()
+          if (expr.type === AST_NODE_TYPES.CallExpression) {
+            const callee = expr.callee;
+            return (
+              callee.type === AST_NODE_TYPES.Identifier &&
+              callee.name === memoizeAlias
+            );
           }
-          const callee = decorator.expression.callee;
-          return (
-            callee.type === AST_NODE_TYPES.Identifier &&
-            callee.name === memoizeAlias
-          );
+          // @Memoize (no parens)
+          if (expr.type === AST_NODE_TYPES.Identifier) {
+            return expr.name === memoizeAlias;
+          }
+          return false;
         });
 
-        if (!hasDecorator && hasMemoizeImport) {
-          context.report({
-            node,
-            messageId: 'requireMemoize',
-            fix(fixer) {
-              // Add import if needed
-              // Add decorator
-              return fixer.insertTextBefore(
-                node,
-                `@${memoizeAlias}()\n${' '.repeat(node.loc.start.column)}`,
-              );
-            },
-          });
+        if (hasDecorator) {
+          return;
         }
+
+        context.report({
+          node,
+          messageId: 'requireMemoize',
+          fix(fixer) {
+            const fixes = [] as any[];
+
+            // Add import if it's not already present; ensure we only add once per file
+            if (!hasMemoizeImport && !scheduledImportFix) {
+              const sourceCode = context.getSourceCode();
+              const programBody = sourceCode.ast.body;
+              const firstImport = programBody.find(
+                (n) => n.type === AST_NODE_TYPES.ImportDeclaration,
+              );
+              const anchorNode = (firstImport ?? programBody[0]) as
+                | (typeof programBody)[number]
+                | undefined;
+
+              if (anchorNode) {
+                const text = sourceCode.text;
+                const anchorStart = anchorNode.range![0];
+                const lineStart = text.lastIndexOf('\n', anchorStart - 1) + 1;
+                const leadingWhitespace = text.slice(lineStart, anchorStart).match(/^[ \t]*/)?.[0] ?? '';
+                const importLine = `${leadingWhitespace}import { Memoize } from 'typescript-memoize';\n`;
+                fixes.push(
+                  fixer.insertTextBeforeRange([lineStart, lineStart], importLine),
+                );
+              } else {
+                // Fallback: empty file
+                fixes.push(
+                  fixer.insertTextBeforeRange(
+                    [0, 0],
+                    "import { Memoize } from 'typescript-memoize';\n",
+                  ),
+                );
+              }
+              scheduledImportFix = true;
+            }
+
+            // Add decorator for this method
+            fixes.push(
+              fixer.insertTextBefore(
+                node as any,
+                `@${memoizeAlias}()\n${' '.repeat(node.loc.start.column)}`,
+              ),
+            );
+
+            return fixes;
+          },
+        });
       },
     };
   },

--- a/src/tests/enforce-memoize-async.test.ts
+++ b/src/tests/enforce-memoize-async.test.ts
@@ -91,6 +91,53 @@ ruleTesterTs.run('enforce-memoize-async', enforceMemoizeAsync, {
         }
       `,
     },
+    // Already decorated without parentheses
+    {
+      code: `
+        import { Memoize } from 'typescript-memoize';
+        class Example {
+          @Memoize
+          async getData() {
+            return await fetch('data');
+          }
+        }
+      `,
+    },
+    // Other decorator present and also Memoize()
+    {
+      code: `
+        import { Memoize } from 'typescript-memoize';
+        function Log(): MethodDecorator { return () => {}; }
+        class Example {
+          @Log()
+          @Memoize()
+          async getData(id?: string) {
+            return await fetch('data');
+          }
+        }
+      `,
+    },
+    // Async method with two params should be ignored
+    {
+      code: `
+        class Example {
+          async getData(id: string, page = 1) {
+            return await fetch('data');
+          }
+        }
+      `,
+    },
+    // Static async generator method should be ignored
+    {
+      code: `
+        import { Memoize } from 'typescript-memoize';
+        class Example {
+          static async *stream() {
+            yield 1;
+          }
+        }
+      `,
+    },
   ],
   invalid: [
     // Missing decorator on async method with no parameters
@@ -152,6 +199,183 @@ ruleTesterTs.run('enforce-memoize-async', enforceMemoizeAsync, {
           @Cache()
           async getData() {
             return await fetch('data');
+          }
+        }
+      `,
+    },
+    // Missing import on async method with no parameters
+    {
+      code: `
+        class Example {
+          async getData() {
+            return await fetch('data');
+          }
+        }
+      `,
+      errors: [{ messageId: 'requireMemoize' }],
+      output: `
+        import { Memoize } from 'typescript-memoize';
+        class Example {
+          @Memoize()
+          async getData() {
+            return await fetch('data');
+          }
+        }
+      `,
+    },
+    // Missing import with existing other imports; Memoize import should be first
+    {
+      code: `
+        import { something } from 'lib';
+        export class Example {
+          async getData(id?: string) {
+            return await fetch('data');
+          }
+        }
+      `,
+      errors: [{ messageId: 'requireMemoize' }],
+      output: `
+        import { Memoize } from 'typescript-memoize';
+        import { something } from 'lib';
+        export class Example {
+          @Memoize()
+          async getData(id?: string) {
+            return await fetch('data');
+          }
+        }
+      `,
+    },
+    // Multiple async methods: add decorator to each eligible method, ignore 2+ param method
+    {
+      code: `
+        class Example {
+          async a() { return 1; }
+          async b(x: string) { return x; }
+          async c(x: string, y: number) { return x + y; }
+        }
+      `,
+      errors: [{ messageId: 'requireMemoize' }, { messageId: 'requireMemoize' }],
+      output: `
+        import { Memoize } from 'typescript-memoize';
+        class Example {
+          @Memoize()
+          async a() { return 1; }
+          @Memoize()
+          async b(x: string) { return x; }
+          async c(x: string, y: number) { return x + y; }
+        }
+      `,
+    },
+    // Parameter with default value still counts as one parameter
+    {
+      code: `
+        class Example {
+          async getData(id: string = 'x') {
+            return id;
+          }
+        }
+      `,
+      errors: [{ messageId: 'requireMemoize' }],
+      output: `
+        import { Memoize } from 'typescript-memoize';
+        class Example {
+          @Memoize()
+          async getData(id: string = 'x') {
+            return id;
+          }
+        }
+      `,
+    },
+    // Rest parameter still counts as one parameter
+    {
+      code: `
+        class Example {
+          async getAll(...ids: string[]) {
+            return ids.length;
+          }
+        }
+      `,
+      errors: [{ messageId: 'requireMemoize' }],
+      output: `
+        import { Memoize } from 'typescript-memoize';
+        class Example {
+          @Memoize()
+          async getAll(...ids: string[]) {
+            return ids.length;
+          }
+        }
+      `,
+    },
+    // With other decorators present; Memoize should be inserted above others
+    {
+      code: `
+        function Log(): MethodDecorator { return () => {}; }
+        class Example {
+          @Log()
+          async compute() {
+            return 1;
+          }
+        }
+      `,
+      errors: [{ messageId: 'requireMemoize' }],
+      output: `
+        import { Memoize } from 'typescript-memoize';
+        function Log(): MethodDecorator { return () => {}; }
+        class Example {
+          @Memoize()
+          @Log()
+          async compute() {
+            return 1;
+          }
+        }
+      `,
+    },
+    // Reproduction: CohortIO with three async methods should all be decorated
+    {
+      code: `
+        export class CohortIO {
+          public async execute() {
+            const cohorts = await this.fetchCohorts();
+            if (cohorts.length === 0) { return; }
+            const updates = this.buildUpdates(cohorts);
+            if (updates.length === 0) { return; }
+            await this.applyUpdates(updates);
+          }
+
+          private async fetchCohorts() {
+            return [] as any[];
+          }
+
+          private async applyUpdates(updates: Partial<any>[]) {
+            return;
+          }
+        }
+      `,
+      errors: [
+        { messageId: 'requireMemoize' },
+        { messageId: 'requireMemoize' },
+        { messageId: 'requireMemoize' },
+      ],
+      output: `
+        import { Memoize } from 'typescript-memoize';
+        export class CohortIO {
+          @Memoize()
+          public async execute() {
+            const cohorts = await this.fetchCohorts();
+            if (cohorts.length === 0) { return; }
+            const updates = this.buildUpdates(cohorts);
+            if (updates.length === 0) { return; }
+            await this.applyUpdates(updates);
+          }
+
+          @Memoize()
+          private async fetchCohorts() {
+            return [] as any[];
+          }
+
+          @Memoize()
+          private async applyUpdates(updates: Partial<any>[]) {
+            return;
           }
         }
       `,


### PR DESCRIPTION
Fixes the `enforce-memoize-async` ESLint rule to correctly detect and autofix async class methods missing the `@Memoize` decorator, including handling missing imports.

The rule previously failed to detect async methods in certain class structures (like `CohortIO`) and did not correctly insert the `Memoize` import when it was entirely missing from the file. This led to the rule not enforcing memoization as intended. The fix improves decorator detection, ensures the import is added correctly with proper indentation and placement, and expands the test suite to cover various edge cases such as multiple async methods, existing imports, other decorators, and different parameter types (default, rest).

---
<a href="https://cursor.com/background-agent?bcId=bc-31301847-6f94-49c7-8442-88a267069f64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31301847-6f94-49c7-8442-88a267069f64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

