### PR TITLE
Fix eslint rule for directive comments

### DIFF
--- a/src/rules/prefer-block-comments-for-declarations.ts
+++ b/src/rules/prefer-block-comments-for-declarations.ts
@@ -24,13 +24,10 @@ export const preferBlockCommentsForDeclarations: TSESLint.RuleModule<
 
       // Ignore ESLint directive comments
       const commentText = comment.value.trim();
-      if (
-        commentText.startsWith('eslint-disable') ||
-        commentText.startsWith('eslint-enable') ||
-        commentText.startsWith('eslint-env') ||
-        commentText.startsWith('global ') ||
-        commentText.startsWith('globals ')
-      ) {
+      const isDirective = /^(?:eslint(?:-disable(?:-next-line)?|-enable|-env)\b|eslint(?:\s|$)|globals?\b|exported\b)/.test(
+        commentText,
+      );
+      if (isDirective) {
         return false;
       }
 

--- a/src/tests/prefer-block-comments-for-declarations.test.ts
+++ b/src/tests/prefer-block-comments-for-declarations.test.ts
@@ -196,3 +196,69 @@ ruleTesterTs.run(
     ],
   },
 );
+
+// Additional valid cases to ensure ESLint directive comments are ignored
+ruleTesterTs.run(
+  'prefer-block-comments-for-declarations (eslint directives)',
+  preferBlockCommentsForDeclarations,
+  {
+    valid: [
+      // Top-of-file block ESLint disables before imports (should be ignored)
+      `/* eslint-disable no-console */
+/* eslint-disable eqeqeq */
+/* eslint-disable max-params */
+/* eslint-disable no-undef */
+/* eslint-disable no-alert */
+import { ComponentProps, ComponentType, FC, useMemo } from 'react';
+
+// A real declaration after imports
+/** description */
+export type AfterImports = { a: number };`,
+
+      // Block ESLint disable directly before a declaration
+      `/* eslint-disable no-console */
+function foo() { console.log('x'); }`,
+
+      // Block ESLint enable directly before a declaration
+      `/* eslint-enable no-console */
+const value = 1;`,
+
+      // Block eslint rule configuration before a declaration
+      `/* eslint eqeqeq: "error", curly: "error" */
+interface Cfg { id: number }`,
+
+      // Block globals declaration
+      `/* global window, document */
+type Env = { w: typeof window; d: typeof document };`,
+
+      // Block exported directive
+      `/* exported SOME_CONST */
+const SOME_CONST = 42;`,
+
+      // Line eslint rule configuration before a declaration
+      `// eslint eqeqeq: 0, curly: 0
+class A {}`,
+
+      // Line exported directive before a declaration
+      `// exported FOO
+const FOO = 'bar';`,
+
+      // Line global directive (singular) before a declaration
+      `// global process
+enum E { A, B }`,
+
+      // Ensure trimming/spacing is handled
+      `   //    eslint-disable-next-line no-unused-vars
+const X = 1;`,
+
+      // Ensure weird spacing in block comment is ignored
+      `/*eslint-disable no-alert*/
+function alertUser() { /* noop */ }`,
+
+      // Ensure eslint-enable-next-line style comments are ignored if present
+      `// eslint-disable-next-line no-unused-vars
+const unused = 0;`,
+    ],
+    invalid: [],
+  },
+);


### PR DESCRIPTION
Fix `prefer-block-comments-for-declarations` rule to ignore ESLint directive comments and expand test coverage.

The rule was incorrectly flagging ESLint directive comments (like `/* eslint-disable ... */` or `// eslint global ...`) as violations and attempting to auto-fix them. This PR updates the rule to correctly identify and skip these special linter instructions, ensuring they are not treated as regular code comments requiring block format. Extensive tests have been added to cover various directive types and edge cases.

---
<a href="https://cursor.com/background-agent?bcId=bc-1acd250e-5c2a-436b-ac0b-3dd5c98f0a27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1acd250e-5c2a-436b-ac0b-3dd5c98f0a27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded recognition of directive-style line comments before declarations (e.g., eslint-disable/-next-line, eslint-enable, eslint-env, eslint, global/globals, exported), ensuring they’re left unchanged.
- Bug Fixes
  - Reduces false positives where directive comments were previously converted to block comments.
  - Preserves existing behavior for non-directive comments while improving consistency in handling declaration-related comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->