### PR TITLE
Fix ESLint boolean naming rule false positives

### DIFF
--- a/src/tests/enforce-boolean-naming-prefixes-assert-prefixed-non-boolean.test.ts
+++ b/src/tests/enforce-boolean-naming-prefixes-assert-prefixed-non-boolean.test.ts
@@ -1,0 +1,150 @@
+import { ruleTesterTs, ruleTesterJsx } from '../utils/ruleTester';
+import { enforceBooleanNamingPrefixes } from '../rules/enforce-boolean-naming-prefixes';
+
+ruleTesterTs.run(
+  'enforce-boolean-naming-prefixes-assert-prefixed-non-boolean',
+  enforceBooleanNamingPrefixes,
+  {
+    valid: [
+      // Direct call to assert-prefixed function returning input value
+      `
+      function assertSafe<T extends PropertyKey>(key: T) { return key; }
+      const userId = assertSafe(this.uid);
+      `,
+
+      // Member call to assert-prefixed function returning non-boolean
+      `
+      const utils = { assertSafe<T extends PropertyKey>(key: T) { return key; } };
+      const key = utils.assertSafe('abc');
+      `,
+
+      // Generic passthrough with more complex type
+      `
+      function assertSafe<T>(value: T): T { return value; }
+      type User = { id: string };
+      const user = assertSafe<User>({ id: 'u1' });
+      `,
+
+      // Logical AND with assert-prefixed function on the right should not imply boolean
+      `
+      function assertSafe<T>(value: T): T { return value; }
+      const val = foo && assertSafe(getValue());
+      `,
+
+      // Logical OR fallback with object should not be treated as boolean
+      `
+      function assertSafe<T>(value: T): T { return value; }
+      const out = assertSafe(config) || { a: 1 };
+      `,
+
+      // Negation of assert-prefixed call is boolean, but variable not assigned from it
+      `
+      function assertSafe<T>(value: T): T { return value; }
+      const value = assertSafe(getVal());
+      if (!assertSafe(value)) {
+        console.log('not truthy but value itself is non-boolean');
+      }
+      `,
+
+      // Within object literal assignment
+      `
+      function assertSafe<T>(value: T): T { return value; }
+      const obj = { userId: assertSafe(uid) };
+      `,
+
+      // As a parameter default
+      `
+      function assertSafe<T>(value: T): T { return value; }
+      function f(id = assertSafe('x')) { return id; }
+      `,
+
+      // With type annotation non-boolean
+      `
+      function assertSafe<T>(value: T): T { return value; }
+      const id: string = assertSafe('abc');
+      `,
+
+      // Assignment from await assert-prefixed async that returns value
+      `
+      async function assertSafe<T>(value: T): Promise<T> { return value; }
+      async function main() {
+        const id = await assertSafe('x');
+      }
+      `,
+    ],
+    invalid: [
+      // True boolean from assert-prefixed that returns boolean should still be flagged
+      {
+        code: `
+        function assertIsValid(x: unknown): boolean { return typeof x === 'string'; }
+        const isValid = assertIsValid(value);
+        `,
+        errors: [
+          {
+            messageId: 'missingBooleanPrefix',
+            data: {
+              type: 'function',
+              name: 'assertIsValid',
+              prefixes:
+                'is, has, does, can, should, will, was, had, did, would, must, allows, supports, needs, asserts',
+            },
+          },
+        ],
+      },
+
+      // Logical OR that is boolean on the right
+      {
+        code: `
+        function assertIsEnabled(): boolean { return true; }
+        const enabled = something || assertIsEnabled();
+        `,
+        errors: [
+          {
+            messageId: 'missingBooleanPrefix',
+            data: {
+              type: 'function',
+              name: 'assertIsEnabled',
+              prefixes:
+                'is, has, does, can, should, will, was, had, did, would, must, allows, supports, needs, asserts',
+            },
+          },
+        ],
+      },
+
+      // Negation creates boolean
+      {
+        code: `
+        function assertSafe<T>(value: T): T { return value; }
+        const notOk = !someFlag;
+        `,
+        errors: [
+          {
+            messageId: 'missingBooleanPrefix',
+            data: {
+              type: 'variable',
+              name: 'notOk',
+              prefixes:
+                'is, has, does, can, should, will, was, had, did, would, must, allows, supports, needs, asserts',
+            },
+          },
+        ],
+      },
+    ],
+  },
+);
+
+// Separate JSX-capable tests
+ruleTesterJsx.run(
+  'enforce-boolean-naming-prefixes-assert-prefixed-non-boolean (jsx)',
+  enforceBooleanNamingPrefixes,
+  {
+    valid: [
+      `
+      function assertSafe<T>(value: T): T { return value; }
+      const props = { id: assertSafe(uid) };
+      <div data-id={props.id} />;
+      `,
+    ],
+    invalid: [],
+  },
+);


### PR DESCRIPTION
Fix `enforce-boolean-naming-prefixes` to correctly handle `assert`-prefixed functions that return non-boolean values.

The rule previously assumed all `assert`-prefixed functions returned a boolean, causing false positives for validation utilities that return the input value. This change refines the boolean inference logic to explicitly check the return type for `assert`-prefixed functions and excludes 'asserts' from general naming heuristics, ensuring variables assigned from non-boolean `assert` functions are not flagged.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fbc0446-75c9-4c1d-b9df-4bba22703e03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fbc0446-75c9-4c1d-b9df-4bba22703e03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Smarter boolean-return detection in the boolean naming rule, using scope-aware analysis and type hints.
- Improvements
  - Better handling of function/method calls and property accesses, including case-insensitive checks and assert*-style exclusions.
  - Refined logic for && and || expressions to infer booleans more accurately.
  - Expanded internal boolean prefixes while keeping user-facing messages concise.
- Bug Fixes
  - Fewer false positives/negatives (e.g., avoids treating getters, arrays, and objects as booleans).
  - Clearer error messages with filtered prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->