### PR TITLE
fix: update labeling conventions in research workflows

### DIFF
--- a/.cursor/rules/cursor-hooks-and-workflows.mdc
+++ b/.cursor/rules/cursor-hooks-and-workflows.mdc
@@ -20,7 +20,7 @@ This system automates the ESLint rule development lifecycle using **Cursor Hooks
                                       │
                                       ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│               cursor-rule-research-agent.yml (research-needed)               │
+│               cursor-rule-research-agent.yml (cursor-research)               │
 │     • Searches web for existing ESLint rules                                 │
 │     • Posts findings as issue comment                                        │
 │     • Labels: research-complete, cursor-implement (if NO MATCH)              │
@@ -91,7 +91,7 @@ scripts/
 |-------|---------|
 | `rule-request` | New ESLint rule request |
 | `bug` | Bug in existing rule |
-| `research-needed` | Triggers research workflow |
+| `cursor-research` | Triggers research workflow |
 | `research-complete` | Research has been performed |
 | `cursor-implement` | Triggers implementation workflow |
 | `cursor-fix` | Triggers bug fix workflow |
@@ -100,7 +100,7 @@ scripts/
 
 ### 1. Research Workflow (`cursor-rule-research-agent.yml`)
 
-**Trigger**: Issue labeled with `research-needed`
+**Trigger**: Issue labeled with `cursor-research`
 
 **Purpose**: Search for existing ESLint rules before implementing
 
@@ -110,7 +110,7 @@ scripts/
 3. Agent writes findings to `.cursor/tmp/research-results.md`
 4. Agent runs `post-research-comment.ts` which:
    - Posts findings as issue comment
-   - Removes `research-needed` label
+   - Removes `cursor-research` label
    - Adds `research-complete` label
    - If NO MATCH: Adds `cursor-implement` label
 
@@ -248,7 +248,7 @@ If an agent keeps failing the same check:
 
 ### Research Workflow Not Triggering
 
-- Ensure issue has `research-needed` label
+- Ensure issue has `cursor-research` label
 - Check if research comment already exists (short-circuit logic)
 - Verify `CURSOR_API_KEY` secret is configured
 
@@ -361,7 +361,7 @@ Use [act](https://github.com/nektos/act) to test GitHub workflows locally:
 cat > test-event.json << 'EOF'
 {
   "action": "labeled",
-  "label": { "name": "research-needed" },
+  "label": { "name": "cursor-research" },
   "issue": { "number": 123, "title": "Test Rule", "body": "Test body" }
 }
 EOF

--- a/.github-issues/devops-automation.md
+++ b/.github-issues/devops-automation.md
@@ -102,7 +102,7 @@ Replace current labels with:
 |-----------|-----------|-------------|
 | `enhancement` | `rule-request` | Request for a new ESLint rule |
 | `bug` | `bug` | Bug in an existing rule |
-| N/A | `research-needed` | Triggers deep research workflow |
+| N/A | `cursor-research` | Triggers deep research workflow |
 | N/A | `cursor-implement` | Triggers implementation agent |
 | N/A | `cursor-fix` | Triggers bug fix agent |
 | N/A | `research-complete` | Research has been performed |
@@ -110,7 +110,7 @@ Replace current labels with:
 #### 1.3 Update Issue Templates
 
 Update `.github/ISSUE_TEMPLATE/eslint-rule-request.md`:
-- Change default label from `enhancement` to `rule-request, research-needed`
+- Change default label from `enhancement` to `rule-request, cursor-research`
 - Keep the same structure
 
 Update `.github/ISSUE_TEMPLATE/eslint-rule-bug-report.md`:
@@ -123,7 +123,7 @@ Update `.github/ISSUE_TEMPLATE/eslint-rule-bug-report.md`:
 
 #### 2.1 GitHub Workflow: `cursor-rule-research-agent.yml`
 
-**Trigger**: Issue labeled with `research-needed`
+**Trigger**: Issue labeled with `cursor-research`
 
 **Purpose**: Launch a Cursor Background Agent to research if an ESLint rule already exists.
 
@@ -150,8 +150,8 @@ concurrency:
 jobs:
   research_existing_rules:
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'research-needed') ||
-      (github.event.action == 'reopened' && contains(github.event.issue.labels.*.name, 'research-needed'))
+      (github.event.action == 'labeled' && github.event.label.name == 'cursor-research') ||
+      (github.event.action == 'reopened' && contains(github.event.issue.labels.*.name, 'cursor-research'))
     runs-on: ubuntu-latest
     steps:
       # 1. Check if research comment already exists (short-circuit)
@@ -237,7 +237,7 @@ ISSUE_NUMBER=${issue.number} npx tsx scripts/github/post-research-comment.ts
 The script will:
 1. Post your research findings as a comment on the issue
 2. Manipulate labels based on your recommendation:
-   - Remove `research-needed` label
+   - Remove `cursor-research` label
    - Add `research-complete` label
    - If NO MATCH: Also add `cursor-implement` label
 ```
@@ -250,7 +250,7 @@ The `scripts/github/post-research-comment.ts` file is provided in the starter fi
 2. Detects the recommendation (EXACT MATCH, PARTIAL MATCH, or NO MATCH)
 3. Posts the findings as a comment on the GitHub issue
 4. Manipulates labels:
-   - Removes `research-needed`
+   - Removes `cursor-research`
    - Adds `research-complete`
    - If NO MATCH: Adds `cursor-implement` to trigger implementation agent
    - If MATCH: Tags `@dev` for human review
@@ -258,13 +258,13 @@ The `scripts/github/post-research-comment.ts` file is provided in the starter fi
 #### 2.3 Workflow Behavior After Research
 
 - On `EXACT MATCH` or `PARTIAL MATCH`:
-  - Remove `research-needed` label
+  - Remove `cursor-research` label
   - Add `research-complete` label
   - Do NOT add `cursor-implement` (requires human to import existing rule)
   - Comment tags `@dev` to import the existing rule
 
 - On `NO MATCH`:
-  - Remove `research-needed` label
+  - Remove `cursor-research` label
   - Add `research-complete` label
   - **Automatically add `cursor-implement` label** to trigger implementation agent
 

--- a/.github/ISSUE_TEMPLATE/eslint-rule-request.md
+++ b/.github/ISSUE_TEMPLATE/eslint-rule-request.md
@@ -2,7 +2,7 @@
 name: ESLint Rule Request
 about: Propose a new custom ESLint rule
 title: "[RULE]"
-labels: rule-request, research-needed
+labels: rule-request, cursor-research
 assignees: ''
 
 ---

--- a/.github/workflows/cursor-rule-research-agent.yml
+++ b/.github/workflows/cursor-rule-research-agent.yml
@@ -119,7 +119,7 @@ jobs:
           The script will:
           1. Post your research findings as a comment on the issue
           2. Manipulate labels based on your recommendation:
-             - Remove \`research-needed\` label
+             - Remove \`cursor-research\` label
              - Add \`research-complete\` label
              - If NO MATCH: Also add \`cursor-implement\` label
           PROMPT_ISSUE


### PR DESCRIPTION
- Changed the label from 'research-needed' to 'cursor-research' across various files to align with new labeling conventions.
- Updated the GitHub workflow and issue template to reflect the new label, ensuring consistency in triggering research workflows.
- Adjusted documentation to clarify the purpose and behavior of the updated label in the research process.