### PR TITLE
Research redundant this params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.10.0",
+  "version": "1.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.10.0",
+      "version": "1.12.6",
       "license": "ISC",
       "dependencies": {
         "@types/pluralize": "0.0.33",


### PR DESCRIPTION
Update `@blumintinc/eslint-plugin-blumint` version in `package-lock.json` as a result of dependency updates during ESLint rule research.

This update occurred during the research phase for the `no-redundant-this-params` ESLint rule. The research concluded that no existing rule exactly matches the described functionality, indicating a new custom rule needs to be implemented. This PR primarily reflects the updated dependency versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fd6b759-9193-47c4-b9d9-b7c2b4419d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4fd6b759-9193-47c4-b9d9-b7c2b4419d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

