### PR TITLE
Research unnecessary usememo primitives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.10.0",
+  "version": "1.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.10.0",
+      "version": "1.12.6",
       "license": "ISC",
       "dependencies": {
         "@types/pluralize": "0.0.33",


### PR DESCRIPTION
Update `package-lock.json` to reflect dependency changes after ESLint rule research.

Research for the `no-unnecessary-useMemo-pass-by-value` ESLint rule concluded that no existing rule provides an exact or partial match, necessitating the creation of a new custom rule. This PR updates the lockfile, preparing for subsequent implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5e4d637-95da-430d-a5b0-5cf3f5c599e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5e4d637-95da-430d-a5b0-5cf3f5c599e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

