### PR TITLE
Research readonly array rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.10.0",
+  "version": "1.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.10.0",
+      "version": "1.12.6",
       "license": "ISC",
       "dependencies": {
         "@types/pluralize": "0.0.33",


### PR DESCRIPTION
Update `package-lock.json` to version 1.12.6, a side effect of dependency updates during ESLint rule research.

---
<a href="https://cursor.com/background-agent?bcId=bc-68dfb25f-f7dd-41cb-b9e5-258eef3971ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68dfb25f-f7dd-41cb-b9e5-258eef3971ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

