### PR TITLE
Research redundant type annotation rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.10.0",
+  "version": "1.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.10.0",
+      "version": "1.12.6",
       "license": "ISC",
       "dependencies": {
         "@types/pluralize": "0.0.33",


### PR DESCRIPTION
Updates `package-lock.json` to reflect dependency changes after completing research for a new ESLint rule.

Research for the "Disallow Redundant Type Annotation and Casting" ESLint rule concluded that no existing rule provides an exact match, necessitating the creation of a new custom rule. The `package-lock.json` update is a side effect of running the research script.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec1b0c58-c38a-459d-a05b-ff8baed50e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec1b0c58-c38a-459d-a05b-ff8baed50e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

