### PR TITLE
Research eslint react useCallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.10.0",
+  "version": "1.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.10.0",
+      "version": "1.12.6",
       "license": "ISC",
       "dependencies": {
         "@types/pluralize": "0.0.33",


### PR DESCRIPTION
Update `package-lock.json` to version 1.12.6 to reflect dependency changes after ESLint rule research.

During the process of researching existing ESLint rules for "memo nested React components," project dependencies were updated, leading to a change in the lockfile. The research concluded that no exact match exists, and a new custom rule is needed. The detailed research findings will be posted as a comment on the associated issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-2440dd6e-da14-423b-ae60-c8a47cf9d71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2440dd6e-da14-423b-ae60-c8a47cf9d71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

