### PR TITLE
Research function grouping rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blumintinc/eslint-plugin-blumint",
-  "version": "1.10.0",
+  "version": "1.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blumintinc/eslint-plugin-blumint",
-      "version": "1.10.0",
+      "version": "1.12.6",
       "license": "ISC",
       "dependencies": {
         "@types/pluralize": "0.0.33",


### PR DESCRIPTION
Update `package-lock.json` version as a result of dependency management during ESLint rule research.

The research for the "Vertically Group Related Functions" ESLint rule concluded with "NO MATCH", and the findings were written to `.cursor/tmp/research-results.md`. This `package-lock.json` update reflects minor dependency changes that occurred during the research process.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab1028fc-eee9-4f4a-9fcf-38fa10ce25a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab1028fc-eee9-4f4a-9fcf-38fa10ce25a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

