### PR TITLE
Extend getter boolean naming

### DIFF
--- a/docs/rules/enforce-boolean-naming-prefixes.md
+++ b/docs/rules/enforce-boolean-naming-prefixes.md
@@ -169,7 +169,9 @@ const isNumber = (val: any): val is number => typeof val === "number";
 
 - Getters must follow boolean prefixes when they either declare a `boolean` return type or when every return statement evaluates to a boolean expression (comparisons, logical operators, negations, or identifiers/calls with boolean-style prefixes).
 - Getters are skipped when any branch returns a non-boolean value or mixes boolean and non-boolean returns to avoid false positives on computed property accessors.
+- Boolean inference covers comparison operators including `in` and `instanceof`, so getters like `return 'key' in store` or `return value instanceof Error` are treated as boolean-returning.
 - If inheritance contracts prevent renaming, set `ignoreOverriddenGetters: true` to skip abstract or `override` getters.
+- Accessing underscore-prefixed members (e.g., `this._name`) does not imply a boolean return on its own; those are treated as neutral private fields unless their names match a boolean prefix or suffix.
 
 #### Private/Internal Properties with Underscore Prefix
 

--- a/src/tests/enforce-boolean-naming-prefixes.test.ts
+++ b/src/tests/enforce-boolean-naming-prefixes.test.ts
@@ -110,6 +110,15 @@ ruleTesterTs.run(
     }
     `,
 
+      // Getter returning private non-boolean field should not imply boolean
+      `
+    class PrivateState {
+      get name() {
+        return this._name;
+      }
+    }
+    `,
+
       // Getters with mixed return types are ignored
       `
     class UserWithStatus {
@@ -543,6 +552,52 @@ ruleTesterTs.run(
               type: 'getter',
               name: 'active',
               capitalizedName: 'Active',
+              prefixes:
+                'is, has, does, can, should, will, was, had, did, would, must, allows, supports, needs, asserts',
+            },
+          },
+        ],
+      },
+      {
+        code: `
+      class Dictionary {
+        map = {};
+
+        get keyPresent() {
+          return 'key' in this.map;
+        }
+      }
+      `,
+        errors: [
+          {
+            messageId: 'missingBooleanPrefix',
+            data: {
+              type: 'getter',
+              name: 'keyPresent',
+              capitalizedName: 'KeyPresent',
+              prefixes:
+                'is, has, does, can, should, will, was, had, did, would, must, allows, supports, needs, asserts',
+            },
+          },
+        ],
+      },
+      {
+        code: `
+      class Checker {
+        value: unknown;
+
+        get instance() {
+          return this.value instanceof Error;
+        }
+      }
+      `,
+        errors: [
+          {
+            messageId: 'missingBooleanPrefix',
+            data: {
+              type: 'getter',
+              name: 'instance',
+              capitalizedName: 'Instance',
               prefixes:
                 'is, has, does, can, should, will, was, had, did, would, must, allows, supports, needs, asserts',
             },


### PR DESCRIPTION
Closes #813


<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Extends the `enforce-boolean-naming-prefixes` rule to enforce boolean naming conventions on class getters, improving code consistency and readability.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This enhancement ensures that getters returning boolean values (detected via type annotations or static analysis of return expressions) adhere to the established prefixing rules. A new `ignoreOverriddenGetters` option is introduced to prevent false positives on inherited or abstract getters, addressing a key edge case.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c9ecca2-e76f-43fa-8674-189f37011915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c9ecca2-e76f-43fa-8674-189f37011915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends `enforce-boolean-naming-prefixes` to check boolean-returning getters with improved inference and adds `ignoreOverriddenGetters`; updates docs and tests.
> 
> - **Rule enhancements (`src/rules/enforce-boolean-naming-prefixes.ts`)**
>   - Enforce prefixes on class getters that return booleans (via explicit `boolean` return type or static analysis of all return expressions, incl. `in`/`instanceof`).
>   - Add `ignoreOverriddenGetters` option (schema + default handling) to skip abstract/override getters.
>   - Improve boolean detection: identifier/call heuristics, suffix keywords, leading underscore handling, pluralized prefixes, and refined error prefix formatting.
>   - Support `TSAbstractMethodDefinition`, skip mixed/non-boolean getter returns, and refine prefix checks with normalization.
> - **Docs (`docs/rules/enforce-boolean-naming-prefixes.md`)**
>   - Document getter behavior, special cases, and the `ignoreOverriddenGetters` option with examples.
> - **Tests (`src/tests/enforce-boolean-naming-prefixes.test.ts`)**
>   - Add valid/invalid cases for boolean-returning getters, overridden/abstract getters, and new inference paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5b67e5fa8fc5ce7d8aea49aec68f6a709245b11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule now checks boolean-returning getters and distinguishes getters vs. methods.
  * Added ignoreOverriddenGetters option to skip abstract/overridden getters.
  * Broadened boolean-prefix handling and detection across identifiers, calls, and complex return expressions.

* **Documentation**
  * Updated rule docs with “Boolean getters” section, examples (correct/incorrect), special-case clarifications, and the new option documented.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->