### PR TITLE
Eslint rule https error

### DIFF
--- a/docs/rules/require-https-error-cause.md
+++ b/docs/rules/require-https-error-cause.md
@@ -89,3 +89,8 @@ try {
 
 - You are working in contexts where `HttpsError` is not available or you intentionally want to construct errors outside a `catch` block (those calls are out of scope for this rule).
 - You deliberately do not want to preserve the original error stack (not recommended for production error monitoring).
+
+### Known Limitations
+
+- **Spread Syntax**: The rule does not currently inspect properties introduced via spread syntax in the settings object (e.g., `new HttpsError({ ...config, cause: error })` where `cause` is inside `config`). The `cause` must be explicitly present as a property in the object literal for the rule to detect it.
+- **Computed Properties**: Computed property keys for `cause` (e.g., `new HttpsError({ [computedKey]: error })`) are not supported and will be reported as a missing cause.

--- a/src/rules/require-https-error-cause.ts
+++ b/src/rules/require-https-error-cause.ts
@@ -157,7 +157,10 @@ export const requireHttpsErrorCause = createRule<Options, MessageIds>({
 
       const catchName = activeCatch.paramName;
 
-      // Handle single object argument signature (e.g., new HttpsError({ code: '...', cause: error }))
+      // HttpsError accepts both positional and object-based constructors. This signature
+      // is supported for compatibility with HttpsError overloads, ensuring the rule
+      // can validate the 'cause' property within a settings object to preserve
+      // error chaining for better diagnostics.
       if (
         node.arguments.length === 1 &&
         node.arguments[0].type === AST_NODE_TYPES.ObjectExpression
@@ -167,8 +170,10 @@ export const requireHttpsErrorCause = createRule<Options, MessageIds>({
           (prop): prop is TSESTree.Property =>
             prop.type === AST_NODE_TYPES.Property &&
             !prop.computed &&
-            prop.key.type === AST_NODE_TYPES.Identifier &&
-            prop.key.name === 'cause',
+            ((prop.key.type === AST_NODE_TYPES.Identifier &&
+              prop.key.name === 'cause') ||
+              (prop.key.type === AST_NODE_TYPES.Literal &&
+                prop.key.value === 'cause')),
         );
 
         if (!causeProp) {

--- a/src/tests/require-https-error-cause.test.ts
+++ b/src/tests/require-https-error-cause.test.ts
@@ -104,11 +104,37 @@ ruleTesterTs.run('require-https-error-cause', requireHttpsErrorCause, {
       try {
         await doWork();
       } catch (err) {
-        throw new HttpsError({ cause: err });
+        throw new HttpsError({ 'cause': err });
+      }
+    `,
+    `
+      try {
+        await doWork();
+      } catch (err) {
+        throw new HttpsError({ "cause": err });
+      }
+    `,
+    `
+      try {
+        await doWork();
+      } catch (err) {
+        const cfg = { code: 'internal' };
+        throw new HttpsError({ ...cfg, cause: err });
       }
     `,
   ],
   invalid: [
+    {
+      code: `
+        try {
+          await doWork();
+        } catch (error) {
+          const cfg = { cause: error };
+          throw new HttpsError({ ...cfg });
+        }
+      `,
+      errors: [{ messageId: 'missingCause' }],
+    },
     {
       code: `
         try {


### PR DESCRIPTION
Closes #1095


Fixes `@blumintinc/blumint/require-https-error-cause` to correctly validate `HttpsError` constructors using a settings object for the `cause`.

The rule previously only checked for a positional `cause` argument, leading to false positives when the `HttpsError` was instantiated with a single object containing a `cause` property. This change updates the rule to inspect the settings object for the `cause` property and validate its value against the catch binding.

---
<a href="https://cursor.com/background-agent?bcId=bc-be75b545-6d2c-4e2d-bca5-a1a9cb2a3467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be75b545-6d2c-4e2d-bca5-a1a9cb2a3467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Enhances rule behavior**
> 
> - Adds support for validating `cause` when `HttpsError` is constructed with a single settings object (checks `cause` property and ensures it references the catch binding).
> - Retains positional-arg validation and improves error reporting when `cause` is missing or not bound to the catch variable.
> 
> **Tests**
> 
> - Adds valid/invalid cases for object-form constructors, including spread usage and non-identifier causes.
> 
> **Docs**
> 
> - Updates rule docs with examples for object and positional forms, and adds Known Limitations for spread/computed properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29015b7b5679b109d6a15f93b555a80ec66f0284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for providing an error cause via a settings object (cause property) in addition to the existing fourth positional argument.

* **Documentation**
  * Clarified guidance to always bind the full caught error (e.g., catch (error)) and expanded examples showing valid and invalid patterns.
  * Added Known Limitations describing constraints with spread syntax and computed property keys for the cause.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->