### PR TITLE
Eslint rule prefer-memoized-props fix

### DIFF
--- a/src/rules/prefer-memoized-props.ts
+++ b/src/rules/prefer-memoized-props.ts
@@ -27,7 +27,7 @@ export const preferMemoizedProps = createRule<[], MessageIds>({
     schema: [],
     messages: {
       memoizeReferenceProp:
-        'Prop "{{propName}}" in a React.memo component receives a {{kind}} that is recreated every render, so memoized children lose referential equality and re-render. Memoize this {{kind}} with useMemo/useCallback or hoist a stable constant so the prop reference stays stable.',
+        'Prop "{{propName}}" in a React.memo component receives a {{kind}} that is recreated every render, so memoized children lose referential equality and re-render. Memoize this {{kind}} with useMemo/useCallback or hoist a stable constant so the prop reference stays stable. If this component uses a custom areEqual function that performs deep equality for this prop, you may safely ignore this warning with // eslint-disable.',
       avoidPrimitiveMemo:
         'useMemo around "{{value}}" only wraps a pass-through value. Primitives already compare by value, and wrapping existing references without creating new objects does not improve stability. Return the value directly instead of adding memoization noise.',
     },
@@ -513,6 +513,15 @@ export const preferMemoizedProps = createRule<[], MessageIds>({
 
       const expression = unwrapExpression(rawExpression);
       const propName = getAttributeName(node.name);
+
+      if (
+        propName === 'sx' ||
+        propName.endsWith('Sx') ||
+        propName === 'style' ||
+        propName.endsWith('Style')
+      ) {
+        return;
+      }
 
       if (expression.type === AST_NODE_TYPES.ObjectExpression) {
         reportReference(expression, propName, 'object');

--- a/src/rules/require-usememo-object-literals.ts
+++ b/src/rules/require-usememo-object-literals.ts
@@ -26,11 +26,14 @@ export const requireUseMemoObjectLiterals = createRule({
           return;
         }
 
-        // Skip if the prop name is 'sx' or ends with 'Sx'
+        // Skip if the prop name is 'sx' or ends with 'Sx', or 'style' or ends with 'Style'
         const propName = node.name.name;
         if (
           typeof propName === 'string' &&
-          (propName === 'sx' || propName.endsWith('Sx'))
+          (propName === 'sx' ||
+            propName.endsWith('Sx') ||
+            propName === 'style' ||
+            propName.endsWith('Style'))
         ) {
           return;
         }

--- a/src/tests/prefer-memoized-props.test.ts
+++ b/src/tests/prefer-memoized-props.test.ts
@@ -130,6 +130,26 @@ ruleTesterJsx.run('prefer-memoized-props', preferMemoizedProps, {
         return <Button />;
       }
     `,
+    `
+      import { memo } from 'react';
+      function Section({ title }) {
+        const style = { color: 'red' };
+        return <Header style={style} title={title} />;
+      }
+      const MemoSection = memo(Section);
+    `,
+    `
+      import { memo } from 'react';
+      const Comp = memo(() => <div sx={{ color: 'red' }} />);
+    `,
+    `
+      import { memo } from 'react';
+      const Comp = memo(() => <div containerSx={{ margin: 10 }} />);
+    `,
+    `
+      import { memo } from 'react';
+      const Comp = memo(() => <div wrapperStyle={{ padding: 20 }} />);
+    `,
   ],
   invalid: [
     {
@@ -213,17 +233,6 @@ ruleTesterJsx.run('prefer-memoized-props', preferMemoizedProps, {
         });
       `,
       errors: [{ messageId: 'avoidPrimitiveMemo' }],
-    },
-    {
-      code: `
-        import { memo } from 'react';
-        function Section({ title }) {
-          const style = { color: 'red' };
-          return <Header style={style} title={title} />;
-        }
-        const MemoSection = memo(Section);
-      `,
-      errors: [{ messageId: 'memoizeReferenceProp' }],
     },
     {
       code: `


### PR DESCRIPTION
Closes #1107


Fixes false positives in `prefer-memoized-props` by ignoring deep-compared props and updates `require-usememo-object-literals` for consistency.

The `prefer-memoized-props` rule was incorrectly flagging props (`sx`, `style`, `*Sx`, `*Style`) that are deep-compared by our custom `blumintAreEqual` implementation, leading to false positives. This PR exempts these props from the rule and updates the error message to guide developers on handling custom `areEqual` functions. The `require-usememo-object-literals` rule was also updated to consistently ignore `style` and `*Style` props.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c13cd2f-fa9c-4b63-8424-f5ff73d44624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c13cd2f-fa9c-4b63-8424-f5ff73d44624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>