### PR TITLE
Eslint rule loop bug

### DIFF
--- a/src/rules/memo-nested-react-components.ts
+++ b/src/rules/memo-nested-react-components.ts
@@ -573,7 +573,11 @@ See: https://react.dev/learn/your-first-component#nesting-and-organizing-compone
           return;
         }
 
-        reportNestedComponentViolation(node, attrName, `the "${attrName}" prop`);
+        reportNestedComponentViolation(
+          node,
+          attrName,
+          `the "${attrName}" prop`,
+        );
       },
     };
   },

--- a/src/rules/react-memoize-literals.ts
+++ b/src/rules/react-memoize-literals.ts
@@ -800,7 +800,10 @@ export const reactMemoizeLiterals = createRule<[], MessageIds>({
       const owner = findEnclosingComponentOrHook(node);
       if (!owner) return;
 
-      if (isInsideAllowedHookCallback(node) || isDeepComparedJSXAttribute(node)) {
+      if (
+        isInsideAllowedHookCallback(node) ||
+        isDeepComparedJSXAttribute(node)
+      ) {
         return;
       }
 

--- a/src/tests/logical-top-to-bottom-grouping.test.ts
+++ b/src/tests/logical-top-to-bottom-grouping.test.ts
@@ -412,7 +412,7 @@ if (triggered) {
 }
     `,
     // Negative case: Variable only read in loop (SHOULD still report)
-    // We expect this NOT to be in valid if it's far from use, 
+    // We expect this NOT to be in valid if it's far from use,
     // but here we just want to ensure isMutatedInLoopAndUsedAfter returns false.
     // If it's far from use, it should be in invalid.
   ],

--- a/src/tests/require-https-error-cause-scope.test.ts
+++ b/src/tests/require-https-error-cause-scope.test.ts
@@ -7,8 +7,11 @@ import { requireHttpsErrorCause } from '../rules/require-https-error-cause';
 
 describe('require-https-error-cause scope shim', () => {
   it('should use sourceCode.getScope in ESLint 9+', () => {
-    const mockScope = { variables: [], upper: null } as unknown as TSESLint.Scope.Scope;
-    
+    const mockScope = {
+      variables: [],
+      upper: null,
+    } as unknown as TSESLint.Scope.Scope;
+
     const mockSourceCode = {
       getScope: jest.fn().mockReturnValue(mockScope),
       getText: jest.fn().mockReturnValue('error'),
@@ -23,14 +26,14 @@ describe('require-https-error-cause scope shim', () => {
     } as unknown as TSESLint.RuleContext<any, any>;
 
     const rule = requireHttpsErrorCause.create(mockContext);
-    
+
     // Trigger CatchClause to set up state
     const catchNode = {
       type: 'CatchClause',
       param: { type: 'Identifier', name: 'error' },
       body: { type: 'BlockStatement', body: [] },
     } as unknown as TSESTree.CatchClause;
-    
+
     (rule as any).CatchClause(catchNode);
 
     // Trigger NewExpression which calls getScopeForNode via isCatchBindingReference
@@ -47,13 +50,18 @@ describe('require-https-error-cause scope shim', () => {
 
     (rule as any).NewExpression(httpsErrorNode);
 
-    expect(mockSourceCode.getScope).toHaveBeenCalledWith(expect.objectContaining({ name: 'error' }));
+    expect(mockSourceCode.getScope).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'error' }),
+    );
     expect(mockContext.getScope).not.toHaveBeenCalled();
   });
 
   it('should fallback to context.getScope in ESLint 8', () => {
-    const mockScope = { variables: [], upper: null } as unknown as TSESLint.Scope.Scope;
-    
+    const mockScope = {
+      variables: [],
+      upper: null,
+    } as unknown as TSESLint.Scope.Scope;
+
     const mockSourceCode = {
       // No getScope method
       getText: jest.fn().mockReturnValue('error'),
@@ -68,14 +76,14 @@ describe('require-https-error-cause scope shim', () => {
     } as unknown as TSESLint.RuleContext<any, any>;
 
     const rule = requireHttpsErrorCause.create(mockContext);
-    
+
     // Trigger CatchClause
     const catchNode = {
       type: 'CatchClause',
       param: { type: 'Identifier', name: 'error' },
       body: { type: 'BlockStatement', body: [] },
     } as unknown as TSESTree.CatchClause;
-    
+
     (rule as any).CatchClause(catchNode);
 
     // Trigger NewExpression

--- a/src/utils/ASTHelpers.ts
+++ b/src/utils/ASTHelpers.ts
@@ -173,7 +173,8 @@ export class ASTHelpers {
         return (node as any).properties.some((property: any) => {
           if (property.type === 'Property') {
             return (
-              (property.computed && this.declarationIncludesIdentifier(property.key)) ||
+              (property.computed &&
+                this.declarationIncludesIdentifier(property.key)) ||
               this.declarationIncludesIdentifier(property.value)
             );
           } else if (property.type === 'SpreadElement') {
@@ -184,10 +185,10 @@ export class ASTHelpers {
 
       case 'Property':
         return (
-          ((node as any).computed && this.declarationIncludesIdentifier((node as any).key)) ||
+          ((node as any).computed &&
+            this.declarationIncludesIdentifier((node as any).key)) ||
           this.declarationIncludesIdentifier((node as any).value)
         );
-
 
       case 'BinaryExpression':
       case 'LogicalExpression':
@@ -402,16 +403,8 @@ export class ASTHelpers {
       case 'AssignmentExpression': {
         const assignExpr = node as any;
         return [
-          ...this.classMethodDependenciesOf(
-            assignExpr.left,
-            graph,
-            className,
-          ),
-          ...this.classMethodDependenciesOf(
-            assignExpr.right,
-            graph,
-            className,
-          ),
+          ...this.classMethodDependenciesOf(assignExpr.left, graph, className),
+          ...this.classMethodDependenciesOf(assignExpr.right, graph, className),
         ];
       }
       case 'BlockStatement':
@@ -424,21 +417,13 @@ export class ASTHelpers {
       case 'IfStatement': {
         const ifStmt = node as any;
         return [
-          ...this.classMethodDependenciesOf(
-            ifStmt.test,
-            graph,
-            className,
-          ),
+          ...this.classMethodDependenciesOf(ifStmt.test, graph, className),
           ...this.classMethodDependenciesOf(
             ifStmt.consequent,
             graph,
             className,
           ),
-          ...this.classMethodDependenciesOf(
-            ifStmt.alternate,
-            graph,
-            className,
-          ),
+          ...this.classMethodDependenciesOf(ifStmt.alternate, graph, className),
         ];
       }
       case 'TSTypeAssertion':
@@ -470,11 +455,7 @@ export class ASTHelpers {
                     graph,
                     className,
                   )
-                : this.classMethodDependenciesOf(
-                    element,
-                    graph,
-                    className,
-                  )),
+                : this.classMethodDependenciesOf(element, graph, className)),
           )
           .flat()
           .filter(Boolean) as string[];
@@ -510,16 +491,8 @@ export class ASTHelpers {
       case 'LogicalExpression': {
         const binLogExpr = node as any;
         return [
-          ...this.classMethodDependenciesOf(
-            binLogExpr.left,
-            graph,
-            className,
-          ),
-          ...this.classMethodDependenciesOf(
-            binLogExpr.right,
-            graph,
-            className,
-          ),
+          ...this.classMethodDependenciesOf(binLogExpr.left, graph, className),
+          ...this.classMethodDependenciesOf(binLogExpr.right, graph, className),
         ];
       }
 
@@ -551,11 +524,7 @@ export class ASTHelpers {
       case 'ConditionalExpression': {
         const condExpr = node as any;
         return [
-          ...this.classMethodDependenciesOf(
-            condExpr.test,
-            graph,
-            className,
-          ),
+          ...this.classMethodDependenciesOf(condExpr.test, graph, className),
           ...this.classMethodDependenciesOf(
             condExpr.consequent,
             graph,
@@ -590,21 +559,9 @@ export class ASTHelpers {
       case 'ForOfStatement': {
         const forOfStmt = node as any;
         return [
-          ...this.classMethodDependenciesOf(
-            forOfStmt.left,
-            graph,
-            className,
-          ),
-          ...this.classMethodDependenciesOf(
-            forOfStmt.body,
-            graph,
-            className,
-          ),
-          ...this.classMethodDependenciesOf(
-            forOfStmt.right,
-            graph,
-            className,
-          ),
+          ...this.classMethodDependenciesOf(forOfStmt.left, graph, className),
+          ...this.classMethodDependenciesOf(forOfStmt.body, graph, className),
+          ...this.classMethodDependenciesOf(forOfStmt.right, graph, className),
         ];
       }
       case 'ForStatement': {
@@ -639,11 +596,7 @@ export class ASTHelpers {
           ...(arrowFunc.params || []).flatMap((param: any) =>
             this.classMethodDependenciesOf(param, graph, className),
           ),
-          ...this.classMethodDependenciesOf(
-            arrowFunc.body,
-            graph,
-            className,
-          ),
+          ...this.classMethodDependenciesOf(arrowFunc.body, graph, className),
         ];
       }
       default:
@@ -674,9 +627,7 @@ export class ASTHelpers {
     }
     if (node.type === AST_NODE_TYPES.IfStatement) {
       const ifStmt = node as any;
-      const consequentHasReturn = this.hasReturnStatement(
-        ifStmt.consequent,
-      );
+      const consequentHasReturn = this.hasReturnStatement(ifStmt.consequent);
       const alternateHasReturn =
         !!ifStmt.alternate && this.hasReturnStatement(ifStmt.alternate);
       return consequentHasReturn && alternateHasReturn;
@@ -707,7 +658,10 @@ export class ASTHelpers {
 
   public static isNodeExported(node: TSESTree.Node) {
     // Checking if the node is exported as a named export.
-    if (node.parent && node.parent.type === AST_NODE_TYPES.ExportNamedDeclaration) {
+    if (
+      node.parent &&
+      node.parent.type === AST_NODE_TYPES.ExportNamedDeclaration
+    ) {
       return true;
     }
 
@@ -882,10 +836,7 @@ export class ASTHelpers {
     if (node.type === AST_NODE_TYPES.TryStatement) {
       return (
         this.returnsJSXFromStatement((node as any).block, context) ||
-        this.returnsJSXFromStatement(
-          (node as any).handler?.body,
-          context,
-        ) ||
+        this.returnsJSXFromStatement((node as any).handler?.body, context) ||
         this.returnsJSXFromStatement((node as any).finalizer, context)
       );
     }
@@ -944,8 +895,7 @@ export class ASTHelpers {
 
     // Treat remaining nodes as statement-path or value checks.
     return (
-      this.returnsJSXFromStatement(node, context) ||
-      this.returnsJSXValue(node)
+      this.returnsJSXFromStatement(node, context) || this.returnsJSXValue(node)
     );
   }
 


### PR DESCRIPTION
Closes #1113


Fixes false positives in `logical-top-to-bottom-grouping` when variables are mutated within a loop and used afterwards.

The rule previously flagged variables declared before a loop, mutated inside it, and used after it, incorrectly suggesting they could be moved closer to their first use. This pattern creates a dependency barrier, making such refactoring impossible or incorrect, and led to erroneous auto-fixes. The fix introduces a check to recognize this specific pattern and prevent the rule from reporting it.

---
<a href="https://cursor.com/background-agent?bcId=bc-f494d7aa-8d28-46ed-a6b2-d7c6b4fdf65e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f494d7aa-8d28-46ed-a6b2-d7c6b4fdf65e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes false positives in `logical-top-to-bottom-grouping`**
> 
> - Adds `isMutatedInLoopAndUsedAfter` and guards late-declaration moves when a loop both mutates a tracked name and that name is referenced after the loop
> - Updates `handleLateDeclarations` to skip auto-fixes across such loops
> - Extends `logical-top-to-bottom-grouping.test.ts` with valid/invalid cases covering `for`/`for-in`/`for-of`/`while`/`do-while`, nested loops, destructuring, updates in test/update clauses, and property mutations
> 
> **Supporting changes**
> 
> - Adds ESLint 8/9 scope-shim tests in `require-https-error-cause-scope.test.ts` to verify `sourceCode.getScope` fallback behavior
> - Minor formatting/whitespace tidy-ups in `memo-nested-react-components.ts`, `react-memoize-literals.ts`, and `utils/ASTHelpers.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5a54064a4055c2d76d098cf8ef863e985caa220. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoid relocating variable declarations across loops when those variables are modified inside a loop and used later, preventing unintended behavior changes.

* **Style**
  * Minor formatting and whitespace adjustments across several rule and helper implementations; no behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->