### PR TITLE
Eslint rule boolean context

### DIFF
--- a/src/tests/prefer-nullish-coalescing-boolean-props.test.ts
+++ b/src/tests/prefer-nullish-coalescing-boolean-props.test.ts
@@ -389,6 +389,30 @@ ruleTesterTs.run(
           tsconfigRootDir,
         },
       },
+      {
+        code: `
+        function constrained<T extends string>(a: T, b: string) {
+          return a || b;
+        }
+        `,
+        filename: 'src/rules/prefer-nullish-coalescing-boolean-props.ts',
+        parserOptions: {
+          project: './tsconfig.json',
+          tsconfigRootDir,
+        },
+      },
+      {
+        code: `
+        function constrainedBool<T extends boolean>(a: T, b: boolean) {
+          return a || b;
+        }
+        `,
+        filename: 'src/rules/prefer-nullish-coalescing-boolean-props.ts',
+        parserOptions: {
+          project: './tsconfig.json',
+          tsconfigRootDir,
+        },
+      },
     ],
     invalid: [
       {


### PR DESCRIPTION
Closes #1125


Fixes a false positive in `prefer-nullish-coalescing-boolean-props` by introducing type-aware linting to correctly identify boolean contexts and non-nullish operands.

The rule previously flagged logical OR (`||`) operations even when the left-hand side was a guaranteed boolean, leading to conflicts with `@typescript-eslint/no-unnecessary-condition`. This PR updates the rule to use TypeScript's type checker to accurately determine if an expression is strictly a boolean or potentially nullish, preventing incorrect suggestions.

---
<a href="https://cursor.com/background-agent?bcId=bc-630dc4e7-52bb-4c7d-bb7d-cd2c7083c121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-630dc4e7-52bb-4c7d-bb7d-cd2c7083c121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces type-aware analysis to correctly allow `||` in boolean contexts and suggest `??` only when the left operand can be nullish.
> 
> - Adds TS utilities (`isBooleanType`, `isPossiblyNullish`) and updates `isInBooleanContext`/`couldBeNullish` to use `ParserServices` and the TypeScript `TypeChecker`, with safe fallbacks
> - Integrates parser services in the rule’s `create` function to gate reports; messages and fixer unchanged
> - Expands tests with TS-project-backed cases and regressions (issue `#1125`), configuring `tsconfigRootDir` and adding valid/invalid scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9fcfa5718ba38243ebc1c8c534650bf143bb933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved suggestions to replace || with ?? by using enhanced type-aware/contextual checks to better detect boolean contexts and values that may be null or undefined.
  * Reduced false positives and made automated fixes safer by ensuring suggestions only apply when the left-hand expression can be nullish and is not used in a boolean context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->