### PR TITLE
Eslint global const style bug

### DIFF
--- a/src/rules/global-const-style.ts
+++ b/src/rules/global-const-style.ts
@@ -53,6 +53,10 @@ export default createRule<[], MessageIds>({
         return true;
       }
 
+      if (target.type === AST_NODE_TYPES.ChainExpression) {
+        return isDynamicValue(target.expression);
+      }
+
       if (target.type === AST_NODE_TYPES.MemberExpression) {
         return isDynamicValue(target.object);
       }

--- a/src/tests/global-const-style.test.ts
+++ b/src/tests/global-const-style.test.ts
@@ -155,6 +155,10 @@ ruleTesterTs.run('global-const-style', rule, {
       code: 'export const deep = new Class().prop.nested.method;',
       filename: 'test.ts',
     },
+    {
+      code: 'export const result = new Service()?.method;',
+      filename: 'test.ts',
+    },
   ],
   invalid: [
     // Missing UPPER_SNAKE_CASE and as const in TypeScript


### PR DESCRIPTION
Closes #1130


Fixes `@blumintinc/blumint/global-const-style` to correctly ignore constants initialized with dynamic `MemberExpression` chains.

The rule's check for dynamic initializers was too shallow, failing to recognize that a `MemberExpression` (e.g., `new Class().property`) whose `object` is a `NewExpression` or `CallExpression` is also dynamic. This led to false positives for helper instances, forcing them into `UPPER_SNAKE_CASE` or requiring `eslint-disable-next-line`.

---
<a href="https://cursor.com/background-agent?bcId=bc-63551b82-1f15-42bc-9930-b770f0cb3a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63551b82-1f15-42bc-9930-b770f0cb3a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses false positives by deep-checking initializer expressions.
> 
> - Add `isDynamicValue` helper to unwrap assertions and detect `CallExpression`, `NewExpression`, `BinaryExpression`, and recurse through `ChainExpression` and `MemberExpression` receivers
> - Replace shallow initializer checks with `isDynamicValue` in the rule to skip dynamic/global consts
> - Expand tests to cover member access on dynamic receivers (e.g., `new Service().helper`, `fetchData().result`, `(a + b).property`, deep chains, optional chaining) and a real-world backoff example
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eb4f27acda86d922ed434c62089d9135e43ae0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic for determining when top-level constant initializers are treated as dynamic, increasing robustness and maintainability without changing public behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->