### PR TITLE
This parameters rule bug

### DIFF
--- a/src/tests/no-redundant-this-params.test.ts
+++ b/src/tests/no-redundant-this-params.test.ts
@@ -171,6 +171,33 @@ ruleTesterTs.run('no-redundant-this-params', noRedundantThisParams, {
       }
     }
     `,
+    `
+    class PropagationStrategizerBase {
+      private beforeSource: any;
+      private afterSource: any;
+
+      private resolveTargetsForSource(source: any) {
+        if (!source) return [];
+        // ... logic processing the source ...
+        return [];
+      }
+
+      public initialize() {
+        const beforeTargets = this.resolveTargetsForSource(this.beforeSource);
+        const afterTargets = this.resolveTargetsForSource(this.afterSource);
+      }
+    }
+    `,
+    `
+    class MixedUsage {
+      private value = 1;
+      private helper(val: any) { return val; }
+      run() {
+        this.helper(this.value);
+        this.helper(123);
+      }
+    }
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Closes #1144


Fixes a false positive in the `no-redundant-this-params` ESLint rule by preventing it from flagging parameters as redundant when a method is used as a generic helper with different `this` members across multiple call sites.

The rule now uses a two-pass approach within each class to analyze all internal call sites for a method. A parameter is only flagged as redundant if it consistently receives the same `this.member` across all internal calls, correctly distinguishing between truly redundant parameters and valid generic helper patterns.

---
<a href="https://cursor.com/background-agent?bcId=bc-d208e03c-74ea-405c-b32b-ba9a35c418c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d208e03c-74ea-405c-b32b-ba9a35c418c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces per-class, two-pass analysis to reduce false positives in `no-redundant-this-params`.
> 
> - Adds `PropertyStats`/`MethodStats` and a `classStatsMap` to track per-method argument property usage across all internal calls
> - Defers reporting to `ClassDeclaration|ClassExpression:exit`, emitting only when `callsWithProperty === totalCalls`
> - Reworks `CallExpression` handling to collect `this`-member accesses per argument, de-duplicate within a single call, and record violations for later reporting
> - Leaves existing message formats intact; no runtime fixes, only detection logic changes
> - Expands tests with valid mixed/repeated call-site patterns (e.g., helper used with different `this` members) and keeps existing invalid cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88d194ee88ae109c1f94802afb2583cf86f6c9dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the no-redundant-this-params linting rule with improved analysis to provide more accurate violation detection and reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->