### PR TITLE
ReactNode complex prop exclusion

### DIFF
--- a/src/rules/memo-compare-deeply-complex-props.ts
+++ b/src/rules/memo-compare-deeply-complex-props.ts
@@ -652,6 +652,16 @@ function isObjectType(ts: typeof import('typescript'), flags: number): boolean {
 function isReactNodeType(type: Type, checker: TypeChecker): boolean {
   const typeString = checker.typeToString(type) || '';
   const symbol = type.getSymbol() || type.aliasSymbol;
+
+  // Check for Ref types
+  if (
+    typeString.includes('Ref<') ||
+    typeString.includes('RefObject<') ||
+    typeString.includes('MutableRefObject<')
+  ) {
+    return true;
+  }
+
   if (symbol) {
     const name = symbol.getName();
     if (
@@ -659,7 +669,10 @@ function isReactNodeType(type: Type, checker: TypeChecker): boolean {
       name === 'ReactElement' ||
       name === 'JSX.Element' ||
       name === 'FC' ||
-      name === 'FunctionComponent'
+      name === 'FunctionComponent' ||
+      name === 'Ref' ||
+      name === 'RefObject' ||
+      name === 'MutableRefObject'
     ) {
       return true;
     }
@@ -818,7 +831,7 @@ function getComplexPropertiesFromType(
   const complexProps: string[] = [];
 
   for (const prop of properties) {
-    if (prop.name === 'children') continue;
+    if (prop.name === 'children' || prop.name === 'ref') continue;
 
     if (
       isPropertyComplex(

--- a/src/rules/memo-compare-deeply-complex-props.ts
+++ b/src/rules/memo-compare-deeply-complex-props.ts
@@ -831,7 +831,13 @@ function getComplexPropertiesFromType(
   const complexProps: string[] = [];
 
   for (const prop of properties) {
-    if (prop.name === 'children' || prop.name === 'ref') continue;
+    if (
+      prop.name === 'children' ||
+      prop.name === 'ref' ||
+      isDefaultDeepCompareProp(prop.name)
+    ) {
+      continue;
+    }
 
     if (
       isPropertyComplex(

--- a/src/tests/memo-compare-deeply-complex-props-repro.test.ts
+++ b/src/tests/memo-compare-deeply-complex-props-repro.test.ts
@@ -1,0 +1,85 @@
+import path from 'path';
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { memoCompareDeeplyComplexProps } from '../rules/memo-compare-deeply-complex-props';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+    project: './tsconfig.json',
+    tsconfigRootDir: path.join(__dirname, '..', '..'),
+    createDefaultProgram: true,
+  },
+});
+
+ruleTester.run(
+  'memo-compare-deeply-complex-props-repro',
+  memoCompareDeeplyComplexProps,
+  {
+    valid: [
+      {
+        filename: 'src/components/ReactNodeProps.tsx',
+        code: `
+import React, { memo } from 'react';
+
+type Props = {
+  avatar?: React.ReactNode;
+  preview: React.ReactElement;
+  renderItem: (data: any) => React.ReactNode;
+  Component: React.FC<any>;
+};
+
+const MyComponent = ({ avatar, preview, renderItem, Component }: Props) => (
+  <div>
+    {avatar}
+    {preview}
+    {renderItem({})}
+    <Component />
+  </div>
+);
+
+export const Wrapped = memo(MyComponent);
+`,
+      },
+    ],
+    invalid: [
+      {
+        filename: 'src/components/MixedPropsRepro.tsx',
+        code: `
+import React, { memo } from 'react';
+
+type Props = {
+  activeChannel: { id: string };
+  Avatar: React.ReactNode;
+  Preview: React.ReactNode;
+};
+
+const MyComponent = ({ activeChannel, Avatar, Preview }: Props) => (
+  <div>{activeChannel.id}</div>
+);
+
+export const Wrapped = memo(MyComponent);
+`,
+        output: `
+import { compareDeeply } from 'src/util/memo';
+import React, { memo } from 'react';
+
+type Props = {
+  activeChannel: { id: string };
+  Avatar: React.ReactNode;
+  Preview: React.ReactNode;
+};
+
+const MyComponent = ({ activeChannel, Avatar, Preview }: Props) => (
+  <div>{activeChannel.id}</div>
+);
+
+export const Wrapped = memo(MyComponent, compareDeeply('activeChannel'));
+`,
+        errors: [{ messageId: 'useCompareDeeply' }],
+      },
+    ],
+  },
+);

--- a/src/tests/memo-compare-deeply-complex-props-repro.test.ts
+++ b/src/tests/memo-compare-deeply-complex-props-repro.test.ts
@@ -61,6 +61,25 @@ const MyComponent = ({ ref, innerRef, customRef }: Props) => (
 export const Wrapped = memo(MyComponent);
 `,
       },
+      {
+        filename: 'src/components/SxStyleProps.tsx',
+        code: `
+import React, { memo } from 'react';
+
+type Props = {
+  sx?: { color: string };
+  containerSx?: { padding: number };
+  style?: React.CSSProperties;
+  wrapperStyle?: any;
+};
+
+const MyComponent = ({ sx, containerSx, style, wrapperStyle }: Props) => (
+  <div sx={sx} style={style} />
+);
+
+export const Wrapped = memo(MyComponent);
+`,
+      },
     ],
     invalid: [
       {

--- a/src/tests/memo-compare-deeply-complex-props-repro.test.ts
+++ b/src/tests/memo-compare-deeply-complex-props-repro.test.ts
@@ -43,6 +43,24 @@ const MyComponent = ({ avatar, preview, renderItem, Component }: Props) => (
 export const Wrapped = memo(MyComponent);
 `,
       },
+      {
+        filename: 'src/components/RefProps.tsx',
+        code: `
+import React, { memo, Ref } from 'react';
+
+type Props = {
+  ref?: Ref<HTMLDivElement>;
+  innerRef: Ref<any>;
+  customRef: React.RefObject<any>;
+};
+
+const MyComponent = ({ ref, innerRef, customRef }: Props) => (
+  <div ref={ref} />
+);
+
+export const Wrapped = memo(MyComponent);
+`,
+      },
     ],
     invalid: [
       {


### PR DESCRIPTION
Closes #1179


Fixes a bug in `memo-compare-deeply-complex-props` ESLint rule to correctly exclude React render props from deep comparison.

The rule previously flagged `ReactNode`, `ReactElement`, `React.FC`, and similar component types as complex props, leading to false positives and unnecessary entries in `compareDeeply()` calls. This PR introduces a robust type-checking helper (`isReactNodeType`) to explicitly identify and exclude these stable function/component references from complexity analysis, ensuring only actual data objects/arrays are flagged.

---
<a href="https://cursor.com/background-agent?bcId=bc-55d2fb8f-73dc-48ef-983c-308ccc0a72ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55d2fb8f-73dc-48ef-983c-308ccc0a72ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes false positives in `memo-compare-deeply-complex-props` by excluding React render/ref props from complexity analysis and refining union handling.
> 
> - Adds `isReactNodeType` to detect `ReactNode`/`ReactElement`/`JSX.Element`/`FC`/`FunctionComponent` and `Ref` types (including functions returning these) and treats them as not complex
> - For union types, short-circuits if any member is a React node type
> - Skips known non-data props (`children`, `ref`, and default deep-compare props like `sx`/`style` variants)
> - When a prop is `any` but annotated with React node/component types, treats it as not complex
> - Introduces targeted tests covering React node, ref, style props (valid) and a mixed case to ensure only data objects require `compareDeeply`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 168c8995d5893e40487739ffd83755a670d22ecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced complex property detection to accurately identify and handle React-specific types and patterns, reducing false positives in prop analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->