### PR TITLE
chore(maintainer): validate against the changed-file gate, not whole-repo lint

### DIFF
--- a/scripts/maintainer.test.ts
+++ b/scripts/maintainer.test.ts
@@ -39,7 +39,9 @@ describe('classifyIssue', () => {
 describe('chooseAgent + branchNameFor', () => {
   it('routes rule-request to implement-rule', () => {
     expect(chooseAgent('rule-request')).toBe('implement-rule');
-    expect(branchNameFor('implement-rule', 42)).toBe('develop-implement-rule-42');
+    expect(branchNameFor('implement-rule', 42)).toBe(
+      'develop-implement-rule-42',
+    );
   });
   it('routes bug and other to fix-bug', () => {
     expect(chooseAgent('bug')).toBe('fix-bug');
@@ -99,7 +101,14 @@ describe('normalizeIssues', () => {
           createdAt: 'd',
         },
       ]),
-    ).toEqual([{ number: 5, title: 'T', labels: ['bug', 'priority-high'], createdAt: 'd' }]);
+    ).toEqual([
+      {
+        number: 5,
+        title: 'T',
+        labels: ['bug', 'priority-high'],
+        createdAt: 'd',
+      },
+    ]);
   });
 
   it('tolerates a missing labels array', () => {
@@ -110,36 +119,62 @@ describe('normalizeIssues', () => {
 });
 
 describe('validateViaStopHooks', () => {
-  it('runs build → lint → test in order and returns true when all pass', () => {
+  it('runs build → eslint on changed files → test, returning true when all pass', () => {
     const calls: string[] = [];
-    const ok = validateViaStopHooks((cmd, args) => calls.push(`${cmd} ${args.join(' ')}`));
+    const ok = validateViaStopHooks(
+      (cmd, args) => calls.push(`${cmd} ${args.join(' ')}`),
+      () => ['src/rules/foo.ts', 'src/util/bar.ts'],
+    );
     expect(ok).toBe(true);
-    expect(calls).toEqual(['npm run build', 'npm run lint', 'npm test']);
+    expect(calls).toEqual([
+      'npm run build',
+      'npx eslint src/rules/foo.ts src/util/bar.ts',
+      'npm test',
+    ]);
+  });
+
+  it('skips the lint step when no source files changed', () => {
+    const calls: string[] = [];
+    const ok = validateViaStopHooks(
+      (cmd, args) => calls.push(`${cmd} ${args.join(' ')}`),
+      () => [],
+    );
+    expect(ok).toBe(true);
+    expect(calls).toEqual(['npm run build', 'npm test']);
   });
 
   it('returns false and stops at the first failing step', () => {
     const calls: string[] = [];
-    const ok = validateViaStopHooks((cmd, args) => {
-      calls.push(`${cmd} ${args.join(' ')}`);
-      if (args.includes('lint')) {
-        throw new Error('lint failed');
-      }
-    });
+    const ok = validateViaStopHooks(
+      (cmd, args) => {
+        calls.push(`${cmd} ${args.join(' ')}`);
+        if (args.includes('eslint')) {
+          throw new Error('lint failed');
+        }
+      },
+      () => ['src/rules/foo.ts'],
+    );
     expect(ok).toBe(false);
-    expect(calls).toEqual(['npm run build', 'npm run lint']);
+    expect(calls).toEqual(['npm run build', 'npx eslint src/rules/foo.ts']);
   });
 });
 
 describe('mergeAndClose', () => {
   it('checks out develop, no-ff merges with a closes-#n message, pushes', () => {
     const calls: string[][] = [];
-    mergeAndClose(
-      { issue: 99, branch: 'develop-fix-bug-99' },
-      (cmd, args) => calls.push([cmd, ...args]),
+    mergeAndClose({ issue: 99, branch: 'develop-fix-bug-99' }, (cmd, args) =>
+      calls.push([cmd, ...args]),
     );
     expect(calls).toEqual([
       ['git', 'checkout', 'develop'],
-      ['git', 'merge', '--no-ff', 'develop-fix-bug-99', '-m', 'chore(repo): merge develop-fix-bug-99 (closes #99)'],
+      [
+        'git',
+        'merge',
+        '--no-ff',
+        'develop-fix-bug-99',
+        '-m',
+        'chore(repo): merge develop-fix-bug-99 (closes #99)',
+      ],
       ['git', 'push', 'origin', 'develop'],
     ]);
   });
@@ -156,9 +191,9 @@ describe('mergeAndClose', () => {
 
 describe('parseMergeArgs', () => {
   it('accepts a numeric --issue and a string --branch', () => {
-    expect(parseMergeArgs({ issue: '42', branch: 'develop-fix-bug-42' })).toEqual(
-      { issue: 42, branch: 'develop-fix-bug-42' },
-    );
+    expect(
+      parseMergeArgs({ issue: '42', branch: 'develop-fix-bug-42' }),
+    ).toEqual({ issue: 42, branch: 'develop-fix-bug-42' });
   });
 
   it('rejects a bare --issue (parsed to true ⇒ would coerce to 1)', () => {
@@ -196,7 +231,9 @@ describe('parseVersionArg', () => {
 describe('releaseIfEmpty', () => {
   it('back-merges origin/main into develop, then promotes develop→main when the queue is empty', () => {
     const calls: string[][] = [];
-    const released = releaseIfEmpty([], {}, (cmd, args) => calls.push([cmd, ...args]));
+    const released = releaseIfEmpty([], {}, (cmd, args) =>
+      calls.push([cmd, ...args]),
+    );
     expect(released).toBe(true);
     expect(calls).toEqual([
       ['git', 'fetch', 'origin', 'main'],
@@ -212,10 +249,8 @@ describe('releaseIfEmpty', () => {
 
   it('does nothing when issues remain', () => {
     const calls: string[][] = [];
-    const released = releaseIfEmpty(
-      [issue(1, ['bug'], 'd')],
-      {},
-      (cmd, args) => calls.push([cmd, ...args]),
+    const released = releaseIfEmpty([issue(1, ['bug'], 'd')], {}, (cmd, args) =>
+      calls.push([cmd, ...args]),
     );
     expect(released).toBe(false);
     expect(calls).toEqual([]);

--- a/scripts/maintainer.test.ts
+++ b/scripts/maintainer.test.ts
@@ -2,6 +2,7 @@ import {
   branchNameFor,
   chooseAgent,
   classifyIssue,
+  isLintablePath,
   isQueueEmpty,
   mergeAndClose,
   normalizeIssues,
@@ -115,6 +116,27 @@ describe('normalizeIssues', () => {
     expect(
       normalizeIssues([{ number: 6, title: 'T', createdAt: 'd' }]),
     ).toEqual([{ number: 6, title: 'T', labels: [], createdAt: 'd' }]);
+  });
+});
+
+describe('isLintablePath', () => {
+  it('accepts source ts/tsx/js/jsx files', () => {
+    expect(isLintablePath('src/rules/foo.ts')).toBe(true);
+    expect(isLintablePath('src/util/bar.tsx')).toBe(true);
+    expect(isLintablePath('scripts/baz.js')).toBe(true);
+  });
+
+  it('excludes tests, .github/, node_modules/, .claude/tmp/, and non-source', () => {
+    expect(isLintablePath('src/rules/foo.test.ts')).toBe(false);
+    expect(isLintablePath('src/rules/foo.spec.tsx')).toBe(false);
+    expect(isLintablePath('.github/scripts/x.ts')).toBe(false);
+    expect(isLintablePath('node_modules/pkg/index.ts')).toBe(false);
+    expect(isLintablePath('src/.claude/tmp/scratch.ts')).toBe(false);
+    expect(isLintablePath('docs/rules/foo.md')).toBe(false);
+  });
+
+  it('does NOT skip a source file whose name merely contains "node_modules"', () => {
+    expect(isLintablePath('src/util/node_modules_shim.ts')).toBe(true);
   });
 });
 

--- a/scripts/maintainer.ts
+++ b/scripts/maintainer.ts
@@ -10,7 +10,8 @@
  * This module owns the parts that must be deterministic and unit-testable:
  *   - which issue to work next (bugs before features, oldest first)
  *   - which subagent + branch name an issue maps to
- *   - the pre-merge validation gate (the same commands the repo stop hook runs)
+ *   - the pre-merge validation gate (build + changed-file lint + test, matching
+ *     the repo stop hook — NOT whole-repo lint, which trips on unrelated debt)
  *   - on an empty queue, back-merge origin/main into develop (absorb the prior
  *     async release commit), then promote develop→main (cure drift)
  *   - notify agora of the published release
@@ -21,12 +22,13 @@
  * Subcommands:
  *   next                          → JSON of the next issue {number,title,kind,agent,branch} or null
  *   count                         → JSON {open, empty}
- *   validate                      → run the stop-hook gate (build + lint + test); exit 1 on failure
+ *   validate                      → run the stop-hook gate (build + changed-file lint + test); exit 1 on failure
  *   merge --issue=N --branch=B    → merge a fix branch into develop (closes #N) [--dry-run]
  *   release                       → if queue empty, sync develop from origin/main then promote develop→main [--dry-run]
  *   dispatch --version=V          → notify agora of a published release
  */
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { dispatch } = require('./dispatch-agora-release');
@@ -163,15 +165,57 @@ const defaultRunner: Runner = (cmd, args) => {
 };
 
 /**
- * Run the same gate the repo stop hook enforces (build → lint → test). Returns
- * true only if all three succeed. Mirrors agent-check.ts's quality checks.
+ * Source files changed on the current branch vs develop that the repo's lint
+ * gate would lint: `.ts/.tsx/.js/.jsx` that still exist, excluding tests,
+ * `.github/`, `node_modules`, and `.claude/tmp/`. Mirrors the filter in
+ * `scripts/claude-hooks/lint-diff.ts`.
  */
-export function validateViaStopHooks(run: Runner = defaultRunner): boolean {
-  const steps: Array<[string, string[]]> = [
-    ['npm', ['run', 'build']],
-    ['npm', ['run', 'lint']],
-    ['npm', ['test']],
-  ];
+function changedLintableFiles(): string[] {
+  let out = '';
+  try {
+    out = execFileSync('git', ['diff', '--name-only', DEVELOP], {
+      encoding: 'utf8',
+    });
+  } catch {
+    return [];
+  }
+  return out
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean)
+    .filter(
+      (file) =>
+        /\.(ts|tsx|js|jsx)$/.test(file) &&
+        !file.startsWith('.github/') &&
+        !file.includes('node_modules') &&
+        !file.includes('.claude/tmp/') &&
+        !/\.(test|spec)\.(ts|tsx|js|jsx)$/.test(file) &&
+        existsSync(resolve(file)),
+    );
+}
+
+/**
+ * Run the gate the repo stop hook ACTUALLY enforces: build, then ESLint on the
+ * source files changed vs develop, then the test suite. Returns true only if
+ * all succeed.
+ *
+ * The lint step deliberately lints only changed files (mirroring
+ * agent-check.ts → lint-diff.ts) rather than a whole-repo `npm run lint`. A
+ * whole-repo lint trips on pre-existing debt in files the fix never touched
+ * (e.g. unrelated `lint:js` errors, or `lint:eslint-docs` drift), which would
+ * make the gate permanently red and force the maintainer to "reason past" a
+ * failure that isn't about its change.
+ */
+export function validateViaStopHooks(
+  run: Runner = defaultRunner,
+  getChangedFiles: () => string[] = changedLintableFiles,
+): boolean {
+  const files = getChangedFiles();
+  const steps: Array<[string, string[]]> = [['npm', ['run', 'build']]];
+  if (files.length > 0) {
+    steps.push(['npx', ['eslint', ...files]]);
+  }
+  steps.push(['npm', ['test']]);
   for (const [cmd, args] of steps) {
     try {
       run(cmd, args);

--- a/scripts/maintainer.ts
+++ b/scripts/maintainer.ts
@@ -165,15 +165,42 @@ const defaultRunner: Runner = (cmd, args) => {
 };
 
 /**
- * Source files changed on the current branch vs develop that the repo's lint
- * gate would lint: `.ts/.tsx/.js/.jsx` that still exist, excluding tests,
- * `.github/`, `node_modules`, and `.claude/tmp/`. Mirrors the filter in
- * `scripts/claude-hooks/lint-diff.ts`.
+ * Whether a path is one the repo's lint gate would lint: a source
+ * `.ts/.tsx/.js/.jsx` file, excluding tests, `.github/`, `node_modules`, and
+ * `.claude/tmp/`. Mirrors the filter in `scripts/claude-hooks/lint-diff.ts`
+ * (the `node_modules` match is path-segment-aware so a source file whose name
+ * merely contains the substring isn't skipped).
+ */
+export function isLintablePath(file: string): boolean {
+  return (
+    /\.(ts|tsx|js|jsx)$/.test(file) &&
+    !/\.(test|spec)\.(ts|tsx|js|jsx)$/.test(file) &&
+    !file.startsWith('.github/') &&
+    !/(^|\/)node_modules(\/|$)/.test(file) &&
+    !file.includes('.claude/tmp/')
+  );
+}
+
+/**
+ * Source files changed ON THIS BRANCH that the lint gate would lint. Diffs from
+ * the merge-base with develop (not the develop tip) so develop commits landed
+ * after this branch diverged don't drag unrelated debt into the gate; the
+ * two-dot diff against that base still includes UNCOMMITTED edits, which matters
+ * because validate runs before the maintainer commits the fix.
  */
 function changedLintableFiles(): string[] {
+  let base = DEVELOP;
+  try {
+    base =
+      execFileSync('git', ['merge-base', DEVELOP, 'HEAD'], {
+        encoding: 'utf8',
+      }).trim() || DEVELOP;
+  } catch {
+    /* fall back to the develop ref */
+  }
   let out = '';
   try {
-    out = execFileSync('git', ['diff', '--name-only', DEVELOP], {
+    out = execFileSync('git', ['diff', '--name-only', base], {
       encoding: 'utf8',
     });
   } catch {
@@ -183,15 +210,7 @@ function changedLintableFiles(): string[] {
     .split('\n')
     .map((file) => file.trim())
     .filter(Boolean)
-    .filter(
-      (file) =>
-        /\.(ts|tsx|js|jsx)$/.test(file) &&
-        !file.startsWith('.github/') &&
-        !file.includes('node_modules') &&
-        !file.includes('.claude/tmp/') &&
-        !/\.(test|spec)\.(ts|tsx|js|jsx)$/.test(file) &&
-        existsSync(resolve(file)),
-    );
+    .filter((file) => isLintablePath(file) && existsSync(resolve(file)));
 }
 
 /**


### PR DESCRIPTION
## Problem
The maintainer's `validateViaStopHooks` ran `npm run build && npm run lint && npm test`. The whole-repo `npm run lint` trips on **pre-existing debt in files the fix never touched** — e.g. `lint:js` (`eslint ./src`) currently has ~736 problems, and `lint:eslint-docs` was drifted (#1230). So the gate is **permanently red regardless of the fix**, forcing the maintainer to "reason past" the failure. That's fragile: a genuinely broken change could be merged because its real error hides among the pre-existing noise.

## Fix
Mirror the gate the repo stop hook **actually** enforces (`agent-check.ts` → `lint-diff.ts`): build → ESLint **only the source files changed vs develop** → test.

- Same filter as `lint-diff.ts`: `.ts/.tsx/.js/.jsx` that still exist, excluding `*.test/spec.*`, `.github/`, `node_modules`, `.claude/tmp/`.
- Lint step is skipped when no source files changed.
- `getChangedFiles` is injectable for deterministic unit tests (3 new tests: changed-files path, no-files path, fail-fast).

This makes the maintainer's pre-merge gate meaningful — it gates *its own change*, not the whole repo's backlog — without requiring the (separate, larger) `lint:js` cleanup first.

## Related
- #1230 clears the `lint:eslint-docs` drift.
- The `lint:js` ~736-problem cleanup is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `validate` command now runs the same pre-merge gate as the repo: build, changed-file lint, and tests.
* **Bug Fixes**
  * Validation now checks only changed source files instead of linting the entire codebase.
  * Improved file filtering to skip generated, temporary, and test files while verifying each file still exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->